### PR TITLE
feat: expose the ability to set Machine specific secrets using processes

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -731,6 +731,21 @@ type MachineProcess struct {
 	CmdOverride        []string          `json:"cmd,omitempty"`
 	UserOverride       string            `json:"user,omitempty"`
 	ExtraEnv           map[string]string `json:"env,omitempty"`
+	Secrets            []MachineSecret   `json:"secrets,omitempty"`
+}
+
+// @description A Secret needing to be set in the environment of the Machine. env_var is required
+// and name can be used to reference a secret name where the environment variable is different
+// from what was set originally using the API. NOTE: When secrets are provided on any process, it
+// will override the secrets provided at the machine level.
+type MachineSecret struct {
+	// EnvVar is required and is the name of the environment variable that will be set from the
+	// secret. It must be a valid environment variable name.
+	EnvVar string `json:"env_var"`
+
+	// Name is optional and when provided is used to reference a secret name where the EnvVar is
+	// different from what was set as the secret name.
+	Name string `json:"name"`
 }
 
 type MachineExecRequest struct {


### PR DESCRIPTION
To be able to override the default secrets set on every machine in an app, we want to support machine specific secrets. To not break any backwards compatibility behavior, we'll limit the ability to use machine specific secrets to one that make use of processes. If a process contains at least one secret, the only secrets injected into the VM/process will be what has been explicitly provided.