### PR TITLE
Format restart timeout as duration instead of nanosecond integer

### DIFF
--- a/flaps/flaps_machines.go
+++ b/flaps/flaps_machines.go
@@ -159,7 +159,7 @@ func (f *Client) Restart(ctx context.Context, in fly.RestartMachineInput, nonce 
 	restartEndpoint := fmt.Sprintf("/%s/restart?force_stop=%t", in.ID, in.ForceStop)
 
 	if in.Timeout != 0 {
-		restartEndpoint += fmt.Sprintf("&timeout=%d", in.Timeout)
+		restartEndpoint += fmt.Sprintf("&timeout=%s", in.Timeout)
 	}
 
 	if in.Signal != "" {


### PR DESCRIPTION
Fixes superfly/flyctl#3342.