### PR TITLE
Add 'pristine' boolean option to HTTPResponseOptions

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -558,7 +558,8 @@ type HTTPOptions struct {
 }
 
 type HTTPResponseOptions struct {
-	Headers map[string]any `json:"headers,omitempty" toml:"headers,omitempty"`
+	Headers  map[string]any `json:"headers,omitempty" toml:"headers,omitempty"`
+	Pristine *bool          `json:"pristine,omitempty" toml:"pristine,omitempty"`
 }
 
 type MachineService struct {


### PR DESCRIPTION
The option indicates that the proxy shouldn't add any fly-specific
headers to HTTP responses.
