### PR TITLE
Add trace-id to flaps error type

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -244,6 +244,7 @@ func (f *Client) _sendRequest(ctx context.Context, method, endpoint string, in, 
 			ResponseStatusCode: resp.StatusCode,
 			ResponseBody:       responseBody,
 			FlyRequestId:       resp.Header.Get(headerFlyRequestId),
+			TraceID:            span.SpanContext().TraceID().String(),
 		}
 	}
 	if out != nil {

--- a/flaps/flaps_error.go
+++ b/flaps/flaps_error.go
@@ -27,6 +27,7 @@ type FlapsError struct {
 	ResponseStatusCode int
 	ResponseBody       []byte
 	FlyRequestId       string
+	TraceID            string
 }
 
 func (fe *FlapsError) Error() string {
@@ -79,6 +80,18 @@ func GetErrorRequestID(err error) string {
 	return ""
 }
 
+type ErrorTraceID interface {
+	ErrTraceID() string
+}
+
+func GetErrorTraceID(err error) string {
+	var ferr ErrorTraceID
+	if errors.As(err, &ferr) {
+		return ferr.ErrTraceID()
+	}
+	return ""
+}
+
 func (fe *FlapsError) StatusCode() *StatusCode {
 	var errResp errorResponse
 	unmarshalErr := json.Unmarshal(fe.ResponseBody, &errResp)
@@ -92,6 +105,10 @@ func (fe *FlapsError) StatusCode() *StatusCode {
 
 func (fe *FlapsError) ErrRequestID() string {
 	return fe.FlyRequestId
+}
+
+func (fe *FlapsError) ErrTraceID() string {
+	return fe.TraceID
 }
 
 func (fe *FlapsError) Is(target error) bool {


### PR DESCRIPTION
We want to log the trace-id on errors so we can easily lookup the command on honeycomb