### PR TITLE
Rename `WorkerStatus` to `HostStatus`

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -40,14 +40,14 @@ type Machine struct {
 	InstanceID string `json:"instance_id,omitempty"`
 	Version    string `json:"version,omitempty"`
 	// PrivateIP is the internal 6PN address of the machine.
-	PrivateIP    string                `json:"private_ip,omitempty"`
-	CreatedAt    string                `json:"created_at,omitempty"`
-	UpdatedAt    string                `json:"updated_at,omitempty"`
-	Config       *MachineConfig        `json:"config,omitempty"`
-	Events       []*MachineEvent       `json:"events,omitempty"`
-	Checks       []*MachineCheckStatus `json:"checks,omitempty"`
-	WorkerStatus string                `json:"worker_status,omitempty"`
-	LeaseNonce   string                `json:"nonce,omitempty"`
+	PrivateIP  string                `json:"private_ip,omitempty"`
+	CreatedAt  string                `json:"created_at,omitempty"`
+	UpdatedAt  string                `json:"updated_at,omitempty"`
+	Config     *MachineConfig        `json:"config,omitempty"`
+	Events     []*MachineEvent       `json:"events,omitempty"`
+	Checks     []*MachineCheckStatus `json:"checks,omitempty"`
+	HostStatus string                `json:"host_status,omitempty"`
+	LeaseNonce string                `json:"nonce,omitempty"`
 }
 
 func (m *Machine) FullImageRef() string {

--- a/volume_types.go
+++ b/volume_types.go
@@ -16,7 +16,7 @@ type Volume struct {
 	HostDedicationID   string    `json:"host_dedication_id"`
 	SnapshotRetention  int       `json:"snapshot_retention"`
 	AutoBackupEnabled  bool      `json:"auto_backup_enabled"`
-	WorkerStatus       string    `json:"worker_status,omitempty"`
+	HostStatus         string    `json:"host_status,omitempty"`
 }
 
 func (v Volume) IsAttached() bool {


### PR DESCRIPTION
(After some discussion, we're renaming this before announcing it.)