### PR TITLE
Fix autostop field documentation

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -583,9 +583,13 @@ type HTTPResponseOptions struct {
 }
 
 type MachineService struct {
-	Protocol                 string                     `json:"protocol,omitempty" toml:"protocol,omitempty"`
-	InternalPort             int                        `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
-	Autostop                 *MachineAutostop           `json:"autostop,omitempty"`
+	Protocol     string `json:"protocol,omitempty" toml:"protocol,omitempty"`
+	InternalPort int    `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
+	// Accepts a string (new format) or a boolean (old format). For backward compatibility with older clients, the API continues to use booleans for "off" and "stop" in responses.
+	// * "off" or false - Do not autostop the Machine.
+	// * "stop" or true - Automatically stop the Machine.
+	// * "suspend" - Automatically suspend the Machine, falling back to a full stop if this is not possible.
+	Autostop                 *MachineAutostop           `json:"autostop,omitempty" swaggertype:"string" enums:"off,stop,suspend"`
 	Autostart                *bool                      `json:"autostart,omitempty"`
 	MinMachinesRunning       *int                       `json:"min_machines_running,omitempty"`
 	Ports                    []MachinePort              `json:"ports,omitempty" toml:"ports,omitempty"`


### PR DESCRIPTION
After #80, the generated documentation shows the integer values of the constants for the `MachineAutostop` type. Fix this, document the meaning of the new options, and note that the old boolean format still works.