### PR TITLE
Pass context into flaps Retry function so lease attempt can cancel

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -164,7 +164,7 @@ func (f *Client) WaitForApp(ctx context.Context, name string) error {
 		}
 		return backoff.Permanent(err)
 	}
-	return Retry(op)
+	return Retry(ctx, op)
 }
 
 var snakeCasePattern = regexp.MustCompile("[A-Z]")

--- a/flaps/flaps_machines.go
+++ b/flaps/flaps_machines.go
@@ -225,6 +225,7 @@ func (f *Client) ListFlyAppsMachines(ctx context.Context) ([]*fly.Machine, *fly.
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = 500 * time.Millisecond
 	b.MaxElapsedTime = 5 * time.Second
+	b.Reset()
 	ctx = contextWithAction(ctx, machineList)
 	err := backoff.Retry(func() error {
 		err := f.sendRequestMachines(ctx, http.MethodGet, "", nil, &allMachines, nil)
@@ -319,7 +320,7 @@ func (f *Client) AcquireLease(ctx context.Context, machineID string, ttl *int) (
 		}
 		return backoff.Permanent(err)
 	}
-	if err := Retry(op); err != nil {
+	if err := Retry(ctx, op); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/flaps/retry.go
+++ b/flaps/retry.go
@@ -1,17 +1,19 @@
 package flaps
 
 import (
+	"context"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 )
 
-func Retry(op func() error) error {
+func Retry(ctx context.Context, op func() error) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 100 * time.Millisecond
 	bo.MaxInterval = 500 * time.Millisecond
 	bo.MaxElapsedTime = 0 // no stop
 	bo.RandomizationFactor = 0.5
 	bo.Multiplier = 2
-	return backoff.Retry(op, bo)
+	bo.Reset()
+	return backoff.Retry(op, backoff.WithContext(bo, ctx))
 }


### PR DESCRIPTION
Sending `^C` while trying to acquire a lease currently just hangs.