### PR TITLE
Expose `InternalNumericID` for `App`

### DIFF
--- a/resource_apps.go
+++ b/resource_apps.go
@@ -95,6 +95,7 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 		query ($appName: String!) {
 			app(name: $appName) {
 				id
+				internalNumericId
 				name
 				hostname
 				deployed

--- a/types.go
+++ b/types.go
@@ -216,16 +216,17 @@ func (img *ImageVersion) FullImageRef() string {
 }
 
 type App struct {
-	ID        string
-	Name      string
-	State     string
-	Status    string
-	Deployed  bool
-	Hostname  string
-	AppURL    string
-	Version   int
-	NetworkID int
-	Network   string
+	ID                string
+	InternalNumericID int32
+	Name              string
+	State             string
+	Status            string
+	Deployed          bool
+	Hostname          string
+	AppURL            string
+	Version           int
+	NetworkID         int
+	Network           string
 
 	Release        *Release
 	Organization   Organization


### PR DESCRIPTION
Should this be an int32? The GraphQL API exposes an int for this value, but for the InternalNumericID of orgs, it's a BigInt.
Changing that would probably be a breaking API change though.