### PR TITLE
Allow to specify guest file permissions

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -746,6 +746,9 @@ type File struct {
 
 	// The name of the secret that contains the base64 encoded file contents.
 	SecretName *string `json:"secret_name,omitempty"`
+
+	// Mode bits used to set permissions on this file as accepted by chmod(2).
+	Mode uint32 `json:"mode,omitempty"`
 }
 
 type MachineLease struct {


### PR DESCRIPTION
Will be used by FKS to set permissions for files in projected volumes.