### PR TITLE
add shared ip address to graphql query of `GetApp()`

### DIFF
--- a/resource_apps.go
+++ b/resource_apps.go
@@ -136,6 +136,7 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 						createdAt
 					}
 				}
+				sharedIpAddress
 				imageDetails {
 					registry
 					repository


### PR DESCRIPTION
Return the shared IP address in the `App` object returned from `GetApp()`, which informs user of the public IP address of their app if they allocate a shared IP address (which is the default). This avoids the need to call `GetIPAddress()` explicitly.