### PR TITLE
fetch `revoked_at` field when querying app's limited access tokens

### DIFF
--- a/resource_tokens.go
+++ b/resource_tokens.go
@@ -14,6 +14,7 @@ func (c *Client) GetAppLimitedAccessTokens(ctx context.Context, appName string) 
 						name
 						token
 						expiresAt
+						revokedAt
 						user {
 							email
 						}

--- a/types.go
+++ b/types.go
@@ -313,6 +313,7 @@ type LimitedAccessToken struct {
 	Name      string
 	Token     string
 	ExpiresAt time.Time
+	RevokedAt time.Time
 	User      User
 }
 


### PR DESCRIPTION
So that `flyctl` can have a "Revoked" column when listing tokens.