### PR TITLE
fix: don't discard a response body even if it isn't JSON

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -302,6 +302,7 @@ func (f *Client) getCaveatNames() ([]string, error) {
 	return caveatNames, nil
 }
 
+// handleAPIError returns an error based on the status code and response body.
 func handleAPIError(statusCode int, responseBody []byte) error {
 	switch statusCode / 100 {
 	case 1, 3:
@@ -311,10 +312,10 @@ func handleAPIError(statusCode int, responseBody []byte) error {
 			Error   string `json:"error"`
 			Message string `json:"message,omitempty"`
 		}{}
-		if err := json.Unmarshal(responseBody, &apiErr); err != nil {
-			return fmt.Errorf("request returned non-2xx status, %d", statusCode)
-		}
-		if apiErr.Message != "" {
+		jsonErr := json.Unmarshal(responseBody, &apiErr)
+		if jsonErr != nil {
+			return fmt.Errorf("request returned non-2xx status: %d: %s", statusCode, string(responseBody))
+		} else if apiErr.Message != "" {
 			return fmt.Errorf("%s", apiErr.Message)
 		}
 		return errors.New(apiErr.Error)


### PR DESCRIPTION
We have some components that don't return JSON. For fixing them, this change exposes the response body as is if a request is not JSON.

https://github.com/superfly/flyctl/actions/runs/11440424372/job/31826716962#step:7:47

```
Error: could not destroy machine 48e2d61c133e08: failed to destroy VM 48e2d61c133e08: request returned non-2xx status, 408 (Request ID: 01JAQJJE2YR2FZFSQX92BGK530-sjc)
```