### PR TITLE
fix: don't retry indefinitely

### DIFF
--- a/flaps/retry.go
+++ b/flaps/retry.go
@@ -7,11 +7,12 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
+// Retry the given operation with exponential backoff up to 1 minute.
 func Retry(ctx context.Context, op func() error) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 100 * time.Millisecond
 	bo.MaxInterval = 500 * time.Millisecond
-	bo.MaxElapsedTime = 0 // no stop
+	bo.MaxElapsedTime = 1 * time.Minute
 	bo.RandomizationFactor = 0.5
 	bo.Multiplier = 2
 	bo.Reset()


### PR DESCRIPTION
Before the change, AcquireLease() was blocking indefinitely if the machine's host was offline.