### PR TITLE
Set Network on AppCompact

### DIFF
--- a/resource_apps.go
+++ b/resource_apps.go
@@ -412,6 +412,7 @@ func (client *Client) GetAppCompact(ctx context.Context, appName string) (*AppCo
 				name
 				hostname
 				deployed
+				network
 				status
 				appUrl
 				platformVersion

--- a/types.go
+++ b/types.go
@@ -335,6 +335,7 @@ type AppCompact struct {
 	Status          string
 	Deployed        bool
 	Hostname        string
+	Network         string
 	AppURL          string
 	Organization    *OrganizationBasic
 	PlatformVersion string


### PR DESCRIPTION
To address an issue within Flyctl, we need to specify the Network when dialing the agent. 