### PR TITLE
add GetS3LogsToken to flaps client

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -42,5 +42,5 @@ const (
 	metadataSet
 	metadataGet
 	metadataDel
-	getOIDCToken
+	getS3LogsToken
 )

--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -42,4 +42,5 @@ const (
 	metadataSet
 	metadataGet
 	metadataDel
+	getOIDCToken
 )


### PR DESCRIPTION
Adds a new `GetS3LogsToken` function to the flaps client that calls the new `/orgs/[org_slug]/tokens/s3_logs` endpoint (see superfly/nomad-firecracker#3257 for internal impl).