### PR TITLE
flaps client platform/regions API

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -42,4 +42,5 @@ const (
 	metadataSet
 	metadataGet
 	metadataDel
+	regionsGet
 )

--- a/flaps/flaps_platform.go
+++ b/flaps/flaps_platform.go
@@ -3,8 +3,9 @@ package flaps
 import (
 	"context"
 	"fmt"
-	"github.com/superfly/fly-go"
 	"net/http"
+
+	"github.com/superfly/fly-go"
 )
 
 func (f *Client) GetRegions(ctx context.Context, size string) ([]fly.Region, error) {

--- a/flaps/flaps_platform.go
+++ b/flaps/flaps_platform.go
@@ -1,0 +1,21 @@
+package flaps
+
+import (
+	"context"
+	"fmt"
+	"github.com/superfly/fly-go"
+	"net/http"
+)
+
+func (f *Client) GetRegions(ctx context.Context, size string) ([]fly.Region, error) {
+	ctx = contextWithAction(ctx, regionsGet)
+	endpoint := "/platform/regions"
+	if size != "" {
+		endpoint += fmt.Sprintf("?size=%s", size)
+	}
+	regions := &struct{ Regions []fly.Region }{}
+	if err := f._sendRequest(ctx, http.MethodGet, endpoint, nil, regions, nil); err != nil {
+		return nil, fmt.Errorf("failed to get regions: %w", err)
+	}
+	return regions.Regions, nil
+}

--- a/flaps/flapsaction_string.go
+++ b/flaps/flapsaction_string.go
@@ -44,11 +44,12 @@ func _() {
 	_ = x[metadataSet-33]
 	_ = x[metadataGet-34]
 	_ = x[metadataDel-35]
+	_ = x[regionsGet-36]
 }
 
-const _flapsAction_name = "noneappCreatemachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendsecretCreatesecretDeletesecretGeneratesecretsListvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDel"
+const _flapsAction_name = "noneappCreatemachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendsecretCreatesecretDeletesecretGeneratesecretsListvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGet"
 
-var _flapsAction_index = [...]uint16{0, 4, 13, 26, 39, 51, 62, 73, 87, 97, 108, 122, 133, 149, 168, 187, 206, 217, 226, 239, 254, 268, 280, 292, 306, 317, 327, 339, 352, 361, 381, 399, 411, 423, 434, 445, 456}
+var _flapsAction_index = [...]uint16{0, 4, 13, 26, 39, 51, 62, 73, 87, 97, 108, 122, 133, 149, 168, 187, 206, 217, 226, 239, 254, 268, 280, 292, 306, 317, 327, 339, 352, 361, 381, 399, 411, 423, 434, 445, 456, 466}
 
 func (i flapsAction) String() string {
 	if i < 0 || i >= flapsAction(len(_flapsAction_index)-1) {

--- a/types.go
+++ b/types.go
@@ -610,12 +610,13 @@ type LogEntry struct {
 }
 
 type Region struct {
-	Code             string
-	Name             string
-	Latitude         float32
-	Longitude        float32
-	GatewayAvailable bool
-	RequiresPaidPlan bool
+	Code             string  `json:"code"`
+	Name             string  `json:"name"`
+	Latitude         float32 `json:"latitude"`
+	Longitude        float32 `json:"longitude"`
+	GatewayAvailable bool    `json:"gateway_available"`
+	RequiresPaidPlan bool    `json:"requires_paid_plan"`
+	Capacity         int64   `json:"capacity"`
 }
 
 type Release struct {

--- a/types.go
+++ b/types.go
@@ -609,14 +609,40 @@ type LogEntry struct {
 	}
 }
 
+type GeoRegion string
+
+const (
+	Africa       GeoRegion = "africa"
+	AsiaPacific  GeoRegion = "asia_pacific"
+	Europe       GeoRegion = "europe"
+	NorthAmerica GeoRegion = "north_america"
+	SouthAmerica GeoRegion = "south_america"
+)
+
+var geoRegionNames = map[GeoRegion]string{
+	Africa:       "Africa",
+	AsiaPacific:  "Asia Pacific",
+	Europe:       "Europe",
+	NorthAmerica: "North America",
+	SouthAmerica: "South America",
+}
+
+func (p GeoRegion) String() string {
+	if name, ok := geoRegionNames[p]; ok {
+		return name
+	}
+	return ""
+}
+
 type Region struct {
-	Code             string  `json:"code"`
-	Name             string  `json:"name"`
-	Latitude         float32 `json:"latitude"`
-	Longitude        float32 `json:"longitude"`
-	GatewayAvailable bool    `json:"gateway_available"`
-	RequiresPaidPlan bool    `json:"requires_paid_plan"`
-	Capacity         int64   `json:"capacity"`
+	Code             string    `json:"code"`
+	Name             string    `json:"name"`
+	Latitude         float32   `json:"latitude"`
+	Longitude        float32   `json:"longitude"`
+	GatewayAvailable bool      `json:"gateway_available"`
+	RequiresPaidPlan bool      `json:"requires_paid_plan"`
+	Capacity         int64     `json:"capacity"`
+	GeoRegion        GeoRegion `json:"geo_region"`
 }
 
 type Release struct {


### PR DESCRIPTION
Adds a `capacity` field to the Regions struct, and a `GetRegions` client query that calls the `/platform/regions` API which populates this field.

See superfly/nomad-firecracker#3304 (internal) for further details.