### PR TITLE
GetPlacements API

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -43,4 +43,5 @@ const (
 	metadataGet
 	metadataDel
 	regionsGet
+	placementPost
 )

--- a/flaps/flaps_platform.go
+++ b/flaps/flaps_platform.go
@@ -21,17 +21,30 @@ func (f *Client) GetRegions(ctx context.Context, size string) ([]fly.Region, err
 	return regions.Regions, nil
 }
 
+// Weights override default placement preferences.
+// `region` (default 50) prefers regions closer to the target region.
+// `spread` (default 1) prefers spreading placements across different hosts instead of packed on the same host.
 type Weights map[string]int64
 
 type GetPlacementsRequest struct {
-	VM              *fly.MachineGuest `json:"vm"`
-	Region          string            `json:"region"`
-	Count           int64             `json:"count"`
-	VolumeName      string            `json:"volume_name"`
-	VolumeSizeBytes uint64            `json:"volume_size_bytes"`
-	Weights         *Weights          `json:"weights"`
-	Size            string            `json:"size"`
-	Org             string            `json:"org_slug"`
+	// Resource requirements for the Machine to simulate. Defaults to a performance-1x machine
+	ComputeRequirements *fly.MachineGuest `json:"compute"`
+
+	// Region expression for placement as a comma-delimited set of regions or aliases.
+	// Defaults to "[region],any", to prefer the API endpoint's local region with any other region as fallback.
+	Region string `json:"region"`
+
+	// Number of machines to simulate placement.
+	// Defaults to 0, which returns the org-specific limit for each region.
+	Count uint64 `json:"count"`
+
+	VolumeName      string `json:"volume_name"`
+	VolumeSizeBytes uint64 `json:"volume_size_bytes"`
+
+	// Optional weights to override default placement preferences.
+	Weights *Weights `json:"weights"`
+
+	Org string `json:"org_slug"`
 }
 
 type RegionPlacement struct {
@@ -47,7 +60,7 @@ type GetPlacementsResponse struct {
 func (f *Client) GetPlacements(ctx context.Context, request *GetPlacementsRequest) ([]RegionPlacement, error) {
 	ctx = contextWithAction(ctx, placementPost)
 	endpoint := "/platform/placements"
-	regions := &struct{ Regions []RegionPlacement }{}
+	regions := &GetPlacementsResponse{}
 	if err := f._sendRequest(ctx, http.MethodPost, endpoint, request, regions, nil); err != nil {
 		return nil, fmt.Errorf("failed to get placements: %w", err)
 	}

--- a/flaps/flaps_platform.go
+++ b/flaps/flaps_platform.go
@@ -25,8 +25,7 @@ type Weights map[string]int64
 
 type GetPlacementsRequest struct {
 	VM              *fly.MachineGuest `json:"vm"`
-	DesiredRegion   string            `json:"desired_region"`
-	Regions         []string          `json:"regions"`
+	Region          string            `json:"region"`
 	Count           int64             `json:"count"`
 	VolumeName      string            `json:"volume_name"`
 	VolumeSizeBytes uint64            `json:"volume_size_bytes"`

--- a/flaps/flaps_platform.go
+++ b/flaps/flaps_platform.go
@@ -20,3 +20,37 @@ func (f *Client) GetRegions(ctx context.Context, size string) ([]fly.Region, err
 	}
 	return regions.Regions, nil
 }
+
+type Weights map[string]int64
+
+type GetPlacementsRequest struct {
+	VM              *fly.MachineGuest `json:"vm"`
+	DesiredRegion   string            `json:"desired_region"`
+	Regions         []string          `json:"regions"`
+	Count           int64             `json:"count"`
+	VolumeName      string            `json:"volume_name"`
+	VolumeSizeBytes uint64            `json:"volume_size_bytes"`
+	Weights         *Weights          `json:"weights"`
+	Size            string            `json:"size"`
+	Org             string            `json:"org_slug"`
+}
+
+type RegionPlacement struct {
+	Region      string
+	Count       int
+	Concurrency int
+}
+
+type GetPlacementsResponse struct {
+	Regions []RegionPlacement
+}
+
+func (f *Client) GetPlacements(ctx context.Context, request *GetPlacementsRequest) ([]RegionPlacement, error) {
+	ctx = contextWithAction(ctx, placementPost)
+	endpoint := "/platform/placements"
+	regions := &struct{ Regions []RegionPlacement }{}
+	if err := f._sendRequest(ctx, http.MethodPost, endpoint, request, regions, nil); err != nil {
+		return nil, fmt.Errorf("failed to get placements: %w", err)
+	}
+	return regions.Regions, nil
+}


### PR DESCRIPTION
Adds a GetPlacements function to the flaps client, which invokes the [`/platform/placements`](https://docs.machines.dev/#tag/platform/post/platform/placements) API.