### PR TITLE
feat: expose persist_rootfs

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -377,6 +377,7 @@ type MachineGuest struct {
 	GPUs             int    `toml:"gpus,omitempty" json:"gpus,omitempty"`
 	GPUKind          string `toml:"gpu_kind,omitempty" json:"gpu_kind,omitempty"`
 	HostDedicationID string `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
+	PersistRootfs    string `toml:"persist_rootfs,omitempty" json:"persist_rootfs,omitempty"`
 
 	KernelArgs []string `toml:"kernel_args,omitempty" json:"kernel_args,omitempty"`
 }


### PR DESCRIPTION
The option will be used to skip some operations in the machine's creation path.