### PR TITLE
include raw slug most of the time we get an organization

### DIFF
--- a/resource_organizations.go
+++ b/resource_organizations.go
@@ -32,6 +32,7 @@ func (client *Client) GetOrganizations(ctx context.Context, filters ...Organizat
 				nodes {
 					id
 					slug
+					rawSlug
 					name
 					type
 					paidPlan
@@ -175,6 +176,7 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 				id
 				internalNumericId
 				slug
+				rawSlug
 				name
 				type
 				billable
@@ -210,6 +212,7 @@ func (client *Client) GetDetailedOrganizationBySlug(ctx context.Context, slug st
 		organizationdetails: organization(slug: $slug) {
 			id
 			slug
+			rawSlug
 			name
 			type
 			viewerRole
@@ -374,6 +377,7 @@ func (client *Client) GetOrganizationByApp(ctx context.Context, appName string) 
 				organization {
 					id
 					slug
+					rawSlug
 					paidPlan
 					remoteBuilderImage
 					remoteBuilderApp {


### PR DESCRIPTION
I've discovered some places where we still receive "personal" but need the underlying slug