### PR TITLE
add GetLogs flaps machines client API

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -53,4 +53,5 @@ const (
 	metadataDel
 	regionsGet
 	placementPost
+	logsGet
 )

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -11,12 +11,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/cenkalti/backoff/v4"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/internal/ndjson"
 	"github.com/superfly/fly-go/internal/tracing"
 	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/macaroon"
@@ -233,6 +235,10 @@ func (f *Client) _sendRequest(ctx context.Context, method, endpoint string, in, 
 		}
 	}
 	if out != nil {
+		t := reflect.TypeOf(out)
+		if t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Slice {
+			resp.Body = ndjson.Wrap(resp.Body)
+		}
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 			return fmt.Errorf("failed decoding response: %w", err)
 		}

--- a/flaps/flaps_machines.go
+++ b/flaps/flaps_machines.go
@@ -482,3 +482,18 @@ func (f *Client) Suspend(ctx context.Context, machineID, nonce string) error {
 
 	return nil
 }
+
+func (f *Client) GetLogs(ctx context.Context, machineID string) ([]fly.AppLogEntry, error) {
+	ctx = contextWithAction(ctx, logsGet)
+	endpoint := "/apps/" + f.appName
+	if machineID != "" {
+		endpoint += "/machines/" + machineID
+		ctx = contextWithMachineID(ctx, machineID)
+	}
+	endpoint += "/logs"
+	var entries []fly.AppLogEntry
+	if err := f._sendRequest(ctx, http.MethodGet, endpoint, nil, &entries, nil); err != nil {
+		return nil, fmt.Errorf("failed to get %s: %w", endpoint, err)
+	}
+	return entries, nil
+}

--- a/internal/ndjson/ndjson.go
+++ b/internal/ndjson/ndjson.go
@@ -1,0 +1,36 @@
+package ndjson
+
+import (
+	"bufio"
+	"io"
+)
+
+// Wrap transforms a newline-delimited JSON stream into a JSON array
+// so it can be decoded directly into a slice.
+func Wrap(r io.Reader) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		line := 0
+		wrap := false
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			if line == 0 && s.Bytes()[0] != '[' {
+				wrap = true
+				pw.Write([]byte("["))
+			}
+			if line > 0 && wrap {
+				pw.Write([]byte(","))
+			}
+			pw.Write(s.Bytes())
+			line++
+		}
+		if wrap {
+			pw.Write([]byte("]"))
+		}
+		if err := s.Err(); err != nil {
+			pw.CloseWithError(err)
+		}
+	}()
+	return pr
+}

--- a/types.go
+++ b/types.go
@@ -584,29 +584,65 @@ type LogEntry struct {
 	Level     string
 	Instance  string
 	Region    string
-	Meta      struct {
-		Instance string
-		Region   string
-		Event    struct {
-			Provider string
+	Meta      LogMeta
+}
+
+type LogMeta struct {
+	Instance string
+	Region   string
+	Event    struct {
+		Provider string
+	}
+	HTTP struct {
+		Request struct {
+			ID      string
+			Method  string
+			Version string
 		}
-		HTTP struct {
-			Request struct {
-				ID      string
-				Method  string
-				Version string
-			}
-			Response struct {
-				StatusCode int `json:"status_code"`
-			}
+		Response struct {
+			StatusCode int `json:"status_code"`
 		}
-		Error struct {
-			Code    int
-			Message string
+	}
+	Error struct {
+		Code    int
+		Message string
+	}
+	URL struct {
+		Full string
+	}
+}
+
+type AppLogEntry struct {
+	Event struct {
+		Provider string
+	}
+	Fly struct {
+		App struct {
+			Instance string
+			Name     string
 		}
-		URL struct {
-			Full string
-		}
+		Region string
+	}
+	Host string
+	Log  struct {
+		Level string
+	}
+	Message   string
+	Timestamp string
+}
+
+func (l *AppLogEntry) LogEntry() LogEntry {
+	return LogEntry{
+		Instance:  l.Fly.App.Instance,
+		Level:     l.Log.Level,
+		Message:   l.Message,
+		Region:    l.Fly.Region,
+		Timestamp: l.Timestamp,
+		Meta: LogMeta{
+			Instance: l.Fly.App.Instance,
+			Region:   l.Fly.Region,
+			Event:    struct{ Provider string }{l.Event.Provider},
+		},
 	}
 }
 


### PR DESCRIPTION
`GetLogs` fetches logs from either a specific Machine or (if the `machineID == ""`) an entire App, using the flaps client.

Because the API response is newline-delimited JSON, this PR also includes a wrapper function (`ndjson.Wrap`) that transforms an `io.ReadCloser` response into a standard JSON Array that can be decoded directly into a slice.

The structure of each log lines is `AppLogEntry` which is the same format as NATS app-log messages (extracted from the flyctl repo).