### PR TITLE
build: upgrade Go from 1.21 to 1.24

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,11 +36,10 @@ jobs:
         with:
           go-version-file: "go.mod"
           # check-latest: true
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.54
+          version: v2.1
           working-directory: .
-          skip-pkg-cache: true
 
   test:
     strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,64 +1,64 @@
+version: "2"
+run:
+  issues-exit-code: 1
+  tests: true
 linters:
-  disable-all: true
+  default: none
   enable:
-    # - gofumpt
-    - goimports
     - gomodguard
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unconvert
     - unused
-  fast: true
-
-# options for analysis running
-run:
-  issues-exit-code: 1
-  tests: true
-
-# output configuration options
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-  uniq-by-line: true
-
-# all available settings of specific linters
-linters-settings:
-  gofumpt:
-    module-path: github.com/superfly/flyctl
-
-  errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: true
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: false
-
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io:Close
-
-  gomodguard:
-    allowed:
-      modules:
-        - github.com/cenkalti/backoff/v4
-        - github.com/Khan/genqlient
-        - github.com/google/go-querystring
-        - github.com/PuerkitoBio/rehttp
-        - github.com/superfly/graphql
-        - github.com/superfly/macaroon
-        - github.com/superfly/macaroon/flyio
-        - github.com/superfly/macaroon/tp
-      domains:
-        - golang.org
-        - go.opentelemetry.io
-
-    blocked:
-      modules:
-        - github.com/superfly/flyctl:
-            reason: "`api` can not depend on flyctl project because it pulls tons of dependencies"
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -ST1003 # struct field ... should be ... (mostly acronyms such as Http -> HTTP)
+        - -ST1005 # error strings should not be capitalized
+        - -ST1016 # methods on the same type should have the same receiver name
+        - -QF1001 # could apply De Morgan's law
+        - -QF1002 # could use tagged switch
+        - -QF1008 # could remove embedded field ... from selector
+    gomodguard:
+      allowed:
+        modules:
+          - github.com/cenkalti/backoff/v4
+          - github.com/Khan/genqlient
+          - github.com/google/go-querystring
+          - github.com/PuerkitoBio/rehttp
+          - github.com/superfly/graphql
+          - github.com/superfly/macaroon
+          - github.com/superfly/macaroon/flyio
+          - github.com/superfly/macaroon/tp
+        domains:
+          - golang.org
+          - go.opentelemetry.io
+      blocked:
+        modules:
+          - github.com/superfly/flyctl:
+              reason: '`api` can not depend on flyctl project because it pulls tons of dependencies'
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  settings:
+    gofumpt:
+      module-path: github.com/superfly/flyctl
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/client.go
+++ b/client.go
@@ -203,7 +203,7 @@ func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Quer
 	err := c.client.Run(ctx, req, &resp)
 
 	if resp.Errors != nil {
-		span.RecordError(fmt.Errorf(c.getErrorFromErrors(resp.Errors)))
+		span.RecordError(errors.New(c.getErrorFromErrors(resp.Errors)))
 		span.SetStatus(codes.Error, "failed to do grapqhl request")
 	}
 

--- a/flaps/flaps_machines.go
+++ b/flaps/flaps_machines.go
@@ -323,7 +323,7 @@ func (f *Client) AcquireLease(ctx context.Context, machineID string, ttl *int) (
 	ctx = contextWithAction(ctx, machineAcquireLease)
 	ctx = contextWithMachineID(ctx, machineID)
 
-	var op func() error = func() error {
+	op := func() error {
 		err := f.sendRequestMachines(ctx, http.MethodPost, endpoint, nil, out, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get lease on VM %s: %w", machineID, err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superfly/fly-go
 
-go 1.21
+go 1.24
 
 require (
 	github.com/Khan/genqlient v0.7.1-0.20240819060157-4466fc10e4f3

--- a/resource_ip_addresses.go
+++ b/resource_ip_addresses.go
@@ -170,7 +170,7 @@ func (c *Client) GetEgressIPAddresses(ctx context.Context, appName string) (map[
 
 	ret := make(map[string][]EgressIPAddress)
 	for _, m := range data.App.Machines.Nodes {
-		if m.EgressIpAddresses.Nodes == nil || len(m.EgressIpAddresses.Nodes) == 0 {
+		if len(m.EgressIpAddresses.Nodes) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
1.21 is no longer supported by the Go team. This will unlock other updates such as https://github.com/superfly/fly-go/pull/166.