### PR TITLE
Add MachineCacheDrive type to MachineConfig

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -429,6 +429,10 @@ type MachineRootfs struct {
 	SizeGB  uint64               `toml:"size_gb,omitempty" json:"size_gb,omitempty"`
 }
 
+type MachineCacheDrive struct {
+	SizeMB uint64 `toml:"size_mb,omitempty" json:"size_mb,omitempty"`
+}
+
 // @description The Machine restart policy defines whether and how flyd restarts a Machine after its main process exits. See https://fly.io/docs/machines/guides-examples/machine-restart-policy/.
 type MachineRestart struct {
 	// * no - Never try to restart a Machine automatically when its main process exits, whether that’s on purpose or on a crash.
@@ -832,7 +836,8 @@ type MachineConfig struct {
 	// with containers
 	Volumes []*VolumeConfig `toml:"volumes,omitempty" json:"volumes,omitempty"`
 
-	Rootfs *MachineRootfs `toml:"rootfs,omitempty" json:"rootfs,omitempty"`
+	Rootfs     *MachineRootfs     `toml:"rootfs,omitempty" json:"rootfs,omitempty"`
+	CacheDrive *MachineCacheDrive `toml:"cache_drive,omitempty" json:"cache_drive,omitempty"`
 
 	// Deprecated: use Guest instead
 	VMSize string `toml:"size,omitempty" json:"size,omitempty"`

--- a/machine_types_test.go
+++ b/machine_types_test.go
@@ -375,6 +375,67 @@ func TestMachineRootfsJSON(t *testing.T) {
 	})
 }
 
+func TestMachineCacheDriveJSON(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			input  MachineConfig
+			output string
+		}{
+			{
+				name:   "cache drive with size",
+				input:  MachineConfig{CacheDrive: &MachineCacheDrive{SizeMB: 1024}},
+				output: `{"init":{},"cache_drive":{"size_mb":1024}}`,
+			},
+			{
+				name:   "nil cache drive omitted",
+				input:  MachineConfig{},
+				output: `{"init":{}}`,
+			},
+		}
+		for _, tc := range cases {
+			b, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			} else if string(b) != tc.output {
+				t.Errorf("%s: got %s, want %s", tc.name, string(b), tc.output)
+			}
+		}
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			input  string
+			sizeMB uint64
+		}{
+			{"with size", `{"cache_drive":{"size_mb":2048}}`, 2048},
+			{"no cache drive", `{}`, 0},
+		}
+		for _, tc := range cases {
+			var mc MachineConfig
+			if err := json.Unmarshal([]byte(tc.input), &mc); err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+				continue
+			}
+			if tc.sizeMB == 0 {
+				if mc.CacheDrive != nil {
+					t.Errorf("%s: expected nil cache_drive, got %+v", tc.name, mc.CacheDrive)
+				}
+
+				continue
+			}
+			if mc.CacheDrive == nil {
+				t.Errorf("%s: expected non-nil cache_drive", tc.name)
+				continue
+			}
+			if mc.CacheDrive.SizeMB != tc.sizeMB {
+				t.Errorf("%s: size_mb got %d, want %d", tc.name, mc.CacheDrive.SizeMB, tc.sizeMB)
+			}
+		}
+	})
+}
+
 func TestMachineAutostopUnmarshalJSON(t *testing.T) {
 	type testcase struct {
 		input  string


### PR DESCRIPTION
## Summary

- Adds `MachineCacheDrive` struct with `SizeMB uint64`
- Adds `CacheDrive *MachineCacheDrive` field to `MachineConfig`, alongside `Rootfs`

This mirrors the pattern used by `MachineRootfs` and allows callers to request a cache block device by size rather than relying solely on a feature flag.

## Test plan

- [x] Verify `MachineConfig` serializes/deserializes `cache_drive` correctly
- [ ] Confirm consuming repos (nomad-firecracker) can map this to `flydv1.CacheDrive`