### PR TITLE
docs: add signal enums to machine types

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -336,13 +336,13 @@ type MachineExitEvent struct {
 
 type StopMachineInput struct {
 	ID      string   `toml:"id,omitempty" json:"id,omitempty"`
-	Signal  string   `toml:"signal,omitempty" json:"signal,omitempty"`
+	Signal  string   `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGABRT,SIGALRM,SIGFPE,SIGHUP,SIGILL,SIGINT,SIGKILL,SIGPIPE,SIGQUIT,SIGSEGV,SIGTERM,SIGTRAP,SIGUSR1"`
 	Timeout Duration `toml:"timeout,omitempty" json:"timeout"`
 }
 
 type RestartMachineInput struct {
 	ID               string        `toml:"id,omitempty" json:"id,omitempty"`
-	Signal           string        `toml:"signal,omitempty" json:"signal,omitempty"`
+	Signal           string        `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGABRT,SIGALRM,SIGFPE,SIGHUP,SIGILL,SIGINT,SIGKILL,SIGPIPE,SIGQUIT,SIGSEGV,SIGTERM,SIGTRAP,SIGUSR1"`
 	Timeout          time.Duration `toml:"timeout,omitempty" json:"timeout,omitempty"`
 	ForceStop        bool          `toml:"force_stop,omitempty" json:"force_stop,omitempty"`
 	SkipHealthChecks bool          `toml:"skip_health_checks,omitempty" json:"skip_health_checks,omitempty"`
@@ -903,7 +903,7 @@ type dnsOption struct {
 
 type StopConfig struct {
 	Timeout *Duration `toml:"timeout,omitempty" json:"timeout,omitempty"`
-	Signal  *string   `toml:"signal,omitempty" json:"signal,omitempty"`
+	Signal  *string   `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGABRT,SIGALRM,SIGFPE,SIGHUP,SIGILL,SIGINT,SIGKILL,SIGPIPE,SIGQUIT,SIGSEGV,SIGTERM,SIGTRAP,SIGUSR1"`
 }
 
 // @description A file that will be written to the Machine. One of RawValue or SecretName must be set.


### PR DESCRIPTION
## Summary
- add swagger enum tags for machine signal fields
- document the allowed signal values on stop/restart inputs
- document the allowed signal values on `StopConfig.Signal`

## Why
Several API surfaces accept only a fixed subset of signal strings, but generated docs currently show these fields as free-form strings. Adding enum tags makes the docs match the actual supported values.

## Notes
The enum list matches the signals currently supported by flaps/flyd for machine stop/restart handling.
