### PR TITLE
docs: add SIGUSR2 to machine signal enums

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -336,13 +336,13 @@ type MachineExitEvent struct {
 
 type StopMachineInput struct {
 	ID      string   `toml:"id,omitempty" json:"id,omitempty"`
-	Signal  string   `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGABRT,SIGALRM,SIGFPE,SIGHUP,SIGILL,SIGINT,SIGKILL,SIGPIPE,SIGQUIT,SIGSEGV,SIGTERM,SIGTRAP,SIGUSR1"`
+	Signal  string   `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGHUP,SIGINT,SIGQUIT,SIGKILL,SIGUSR1,SIGUSR2,SIGTERM"`
 	Timeout Duration `toml:"timeout,omitempty" json:"timeout"`
 }
 
 type RestartMachineInput struct {
 	ID               string        `toml:"id,omitempty" json:"id,omitempty"`
-	Signal           string        `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGABRT,SIGALRM,SIGFPE,SIGHUP,SIGILL,SIGINT,SIGKILL,SIGPIPE,SIGQUIT,SIGSEGV,SIGTERM,SIGTRAP,SIGUSR1"`
+	Signal           string        `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGHUP,SIGINT,SIGQUIT,SIGKILL,SIGUSR1,SIGUSR2,SIGTERM"`
 	Timeout          time.Duration `toml:"timeout,omitempty" json:"timeout,omitempty"`
 	ForceStop        bool          `toml:"force_stop,omitempty" json:"force_stop,omitempty"`
 	SkipHealthChecks bool          `toml:"skip_health_checks,omitempty" json:"skip_health_checks,omitempty"`
@@ -903,7 +903,7 @@ type dnsOption struct {
 
 type StopConfig struct {
 	Timeout *Duration `toml:"timeout,omitempty" json:"timeout,omitempty"`
-	Signal  *string   `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGABRT,SIGALRM,SIGFPE,SIGHUP,SIGILL,SIGINT,SIGKILL,SIGPIPE,SIGQUIT,SIGSEGV,SIGTERM,SIGTRAP,SIGUSR1"`
+	Signal  *string   `toml:"signal,omitempty" json:"signal,omitempty" enums:"SIGHUP,SIGINT,SIGQUIT,SIGKILL,SIGUSR1,SIGUSR2,SIGTERM"`
 }
 
 // @description A file that will be written to the Machine. One of RawValue or SecretName must be set.


### PR DESCRIPTION
## Summary
- add `SIGUSR2` to machine signal enum docs
- keep signal values ordered by Unix signal number

## Details
This updates the documented signal enums for:
- `StopMachineInput.Signal`
- `RestartMachineInput.Signal`
- `StopConfig.Signal`

Updated order:
- `SIGHUP` (1)
- `SIGINT` (2)
- `SIGQUIT` (3)
- `SIGKILL` (9)
- `SIGUSR1` (10)
- `SIGUSR2` (12)
- `SIGTERM` (15)
