### PR TITLE
fix: add cookie jar to flaps client

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"regexp"
@@ -68,6 +69,12 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("flaps: can't setup HTTP client to %s: %w", flapsUrl.String(), err)
 	}
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("flaps: can't setup cookie jar for %s: %w", flapsUrl.String(), err)
+	}
+	httpClient.Jar = jar
 
 	userAgent := "fly-go"
 	if opts.UserAgent != "" {

--- a/flaps/flaps_test.go
+++ b/flaps/flaps_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewWithOptionsSetsCookieJar(t *testing.T) {
+	t.Setenv("FLY_FLAPS_BASE_URL", "http://example.com")
+
 	client, err := NewWithOptions(context.Background(), NewClientOpts{})
 	if err != nil {
 		t.Fatalf("NewWithOptions() error = %v", err)
@@ -41,13 +43,13 @@ func TestFlapsClientPersistsPathScopedCookiesPerApp(t *testing.T) {
 			switch req.AppName {
 			case "app-a":
 				http.SetCookie(w, &http.Cookie{
-					Name:  "flaps_app_affinity",
+					Name:  "fly_flaps_affinity",
 					Value: "creator-node-a",
 					Path:  "/v1/apps/app-a",
 				})
 			case "app-b":
 				http.SetCookie(w, &http.Cookie{
-					Name:  "flaps_app_affinity",
+					Name:  "fly_flaps_affinity",
 					Value: "creator-node-b",
 					Path:  "/v1/apps/app-b",
 				})
@@ -57,11 +59,9 @@ func TestFlapsClientPersistsPathScopedCookiesPerApp(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 		case "/v1/apps/app-a/status":
-			assertCookieHeader(t, r, "flaps_app_affinity=creator-node-a")
-			w.WriteHeader(http.StatusOK)
+			assertCookieHeader(w, r, "fly_flaps_affinity=creator-node-a")
 		case "/v1/apps/app-b/status":
-			assertCookieHeader(t, r, "flaps_app_affinity=creator-node-b")
-			w.WriteHeader(http.StatusOK)
+			assertCookieHeader(w, r, "fly_flaps_affinity=creator-node-b")
 		default:
 			http.Error(w, "unexpected path", http.StatusNotFound)
 		}
@@ -92,13 +92,14 @@ func TestFlapsClientPersistsPathScopedCookiesPerApp(t *testing.T) {
 	}
 }
 
-func assertCookieHeader(t *testing.T, r *http.Request, want string) {
-	t.Helper()
-
+func assertCookieHeader(w http.ResponseWriter, r *http.Request, want string) {
 	got := r.Header.Get("Cookie")
 	if got != want {
-		t.Fatalf("cookie header = %q, want %q", got, want)
+		http.Error(w, "cookie header = \""+got+"\", want \""+want+"\"", http.StatusBadRequest)
+		return
 	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func TestSnakeCase(t *testing.T) {

--- a/flaps/flaps_test.go
+++ b/flaps/flaps_test.go
@@ -1,8 +1,105 @@
 package flaps
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func TestNewWithOptionsSetsCookieJar(t *testing.T) {
+	client, err := NewWithOptions(context.Background(), NewClientOpts{})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error = %v", err)
+	}
+	if client.httpClient == nil {
+		t.Fatal("httpClient is nil")
+	}
+	if client.httpClient.Jar == nil {
+		t.Fatal("httpClient.Jar is nil")
+	}
+}
+
+func TestFlapsClientPersistsPathScopedCookiesPerApp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/apps":
+			if r.Method != http.MethodPost {
+				http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+				return
+			}
+
+			var req struct {
+				AppName string `json:"app_name"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "invalid json", http.StatusBadRequest)
+				return
+			}
+
+			switch req.AppName {
+			case "app-a":
+				http.SetCookie(w, &http.Cookie{
+					Name:  "flaps_app_affinity",
+					Value: "creator-node-a",
+					Path:  "/v1/apps/app-a",
+				})
+			case "app-b":
+				http.SetCookie(w, &http.Cookie{
+					Name:  "flaps_app_affinity",
+					Value: "creator-node-b",
+					Path:  "/v1/apps/app-b",
+				})
+			default:
+				http.Error(w, "unexpected app", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/v1/apps/app-a/status":
+			assertCookieHeader(t, r, "flaps_app_affinity=creator-node-a")
+			w.WriteHeader(http.StatusOK)
+		case "/v1/apps/app-b/status":
+			assertCookieHeader(t, r, "flaps_app_affinity=creator-node-b")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("FLY_FLAPS_BASE_URL", server.URL)
+
+	client, err := NewWithOptions(context.Background(), NewClientOpts{})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error = %v", err)
+	}
+
+	ctx := context.Background()
+	for _, req := range []struct {
+		method string
+		path   string
+		body   interface{}
+	}{
+		{method: http.MethodPost, path: "/apps", body: map[string]string{"app_name": "app-a"}},
+		{method: http.MethodPost, path: "/apps", body: map[string]string{"app_name": "app-b"}},
+		{method: http.MethodGet, path: "/apps/app-a/status"},
+		{method: http.MethodGet, path: "/apps/app-b/status"},
+	} {
+		if err := client._sendRequest(ctx, req.method, req.path, req.body, nil, nil); err != nil {
+			t.Fatalf("request %s %s error = %v", req.method, req.path, err)
+		}
+	}
+}
+
+func assertCookieHeader(t *testing.T, r *http.Request, want string) {
+	t.Helper()
+
+	got := r.Header.Get("Cookie")
+	if got != want {
+		t.Fatalf("cookie header = %q, want %q", got, want)
+	}
+}
 
 func TestSnakeCase(t *testing.T) {
 	type testcase struct {


### PR DESCRIPTION
## Summary
- add a cookie jar to the flaps client HTTP client
- persist FLAPS app affinity cookies returned from `POST /v1/apps`
- add a regression test covering two apps with path-scoped cookies

## Why
nfc#4282 adds app affinity cookies so follow-up app-scoped requests get routed back to the FLAPS instance that created the app. The fly-go flaps client needs a cookie jar to retain and resend those cookies automatically.

## Testing
- `go test ./flaps ./...`
