### PR TITLE
Retry idempotent requests on ECONNRESET

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	_ "github.com/Khan/genqlient/generate"
 	genq "github.com/Khan/genqlient/graphql"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/graphql"
 	"go.opentelemetry.io/otel"
@@ -21,6 +23,70 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// graphQLOperationKind returns "query", "mutation", "subscription", or
+// "unknown" if body does not begin with a recognizable operation.
+func graphQLOperationKind(body string) string {
+	// Drop leading whitespace and comments
+	i := 0
+	for i < len(body) {
+		switch body[i] {
+		case ' ', '\t', '\n', '\r', ',':
+			i++
+
+			continue
+		case '#':
+			for i < len(body) && body[i] != '\n' {
+				i++
+			}
+
+			continue
+		}
+
+		break
+	}
+	rest := body[i:]
+	switch {
+	case strings.HasPrefix(rest, "mutation"):
+		return "mutation"
+	case strings.HasPrefix(rest, "subscription"):
+		return "subscription"
+	case strings.HasPrefix(rest, "query"), strings.HasPrefix(rest, "{"):
+		return "query"
+	}
+
+	return "unknown"
+}
+
+// retryQueryOnConnReset runs op, retrying ECONNRESET failures when the request
+// is a query. Mutations and other errors return immediately.
+//
+// This is a separate layer from the rehttp retries in NewHTTPClient because
+// rehttp operates at the HTTP transport and has no way to tell a query from a
+// mutation; retrying ECONNRESET safely requires the idempotency signal that
+// only exists here.
+func retryQueryOnConnReset(ctx context.Context, isQuery bool, op func() error) error {
+	if !isQuery {
+		return op()
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 100 * time.Millisecond
+	b.MaxInterval = 500 * time.Millisecond
+	b.RandomizationFactor = 0.5
+
+	return backoff.Retry(func() error {
+		err := op()
+		switch {
+		case err == nil:
+			return nil
+		case errors.Is(err, syscall.ECONNRESET):
+			return err
+		default:
+			return backoff.Permanent(err)
+		}
+	}, backoff.WithContext(backoff.WithMaxRetries(b, 2), ctx))
+}
 
 var (
 	baseURL          string
@@ -178,17 +244,7 @@ func (c *Client) Run(req *graphql.Request) (Query, error) {
 func (c *Client) Logger() Logger { return c.logger }
 
 func (c *Client) getRequestType(r *graphql.Request) string {
-	query := r.Query()
-
-	if strings.Contains(query, "mutation") {
-		return "mutation"
-	}
-
-	if strings.Contains(query, "query") {
-		return "query"
-	}
-
-	return "unknown"
+	return graphQLOperationKind(r.Query())
 }
 
 func (c *Client) getErrorFromErrors(errors Errors) string {
@@ -217,7 +273,11 @@ func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Quer
 	}
 
 	var resp Query
-	err := c.client.Run(ctx, req, &resp)
+	isQuery := c.getRequestType(req) == "query"
+	err := retryQueryOnConnReset(ctx, isQuery, func() error {
+		resp = Query{}
+		return c.client.Run(ctx, req, &resp)
+	})
 
 	if resp.Errors != nil {
 		span.RecordError(errors.New(c.getErrorFromErrors(resp.Errors)))
@@ -356,5 +416,9 @@ func (c *tracingGenqlientClient) MakeRequest(ctx context.Context, req *genq.Requ
 		}()
 	}
 
-	return c.client.MakeRequest(ctx, req, resp)
+	isQuery := graphQLOperationKind(req.Query) == "query"
+
+	return retryQueryOnConnReset(ctx, isQuery, func() error {
+		return c.client.MakeRequest(ctx, req, resp)
+	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,74 @@
 package fly
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	genq "github.com/Khan/genqlient/graphql"
+	"github.com/superfly/graphql"
+)
+
+// step describes one scripted RoundTrip outcome. If err is non-nil, the
+// RoundTrip returns (nil, err); otherwise it returns a 200 response whose body
+// is body.
+type step struct {
+	err  error
+	body string
+}
+
+type scriptedTripper struct {
+	mu    sync.Mutex
+	calls int
+	steps []step
+}
+
+func (s *scriptedTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.calls >= len(s.steps) {
+		return nil, fmt.Errorf("scriptedTripper: unexpected call %d", s.calls+1)
+	}
+	st := s.steps[s.calls]
+	s.calls++
+
+	if st.err != nil {
+		return nil, st.err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(st.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (s *scriptedTripper) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// connReset returns an error that errors.Is matches as syscall.ECONNRESET,
+// shaped like what the net stack actually produces.
+func connReset() error {
+	return fmt.Errorf("read tcp: %w", syscall.ECONNRESET)
+}
+
+func newTestClient(transport http.RoundTripper) *Client {
+	return NewClientFromOptions(ClientOptions{
+		Name:      "test",
+		Version:   "0",
+		BaseURL:   "http://example.test",
+		Transport: &Transport{UnderlyingTransport: transport},
+	})
+}
 
 func TestTransportSetDefaults_DoesNotOverrideFlyForceRegionFromTransport(t *testing.T) {
 	t.Setenv("FLY_FORCE_REGION", "ord")
@@ -12,5 +80,136 @@ func TestTransportSetDefaults_DoesNotOverrideFlyForceRegionFromTransport(t *test
 
 	if transport.FlyForceRegion != "iad" {
 		t.Fatalf("expected FlyForceRegion to remain %q, got %q", "iad", transport.FlyForceRegion)
+	}
+}
+
+func TestGraphQLOperationKind(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"query keyword", "query Foo { id }", "query"},
+		{"mutation keyword", "mutation Foo { id }", "mutation"},
+		{"subscription keyword", "subscription Foo { id }", "subscription"},
+		{"anonymous selection set", "{ viewer { id } }", "query"},
+		{"leading whitespace", "\n\t  query Foo { id }", "query"},
+		{"leading comment", "# header\nquery Foo { id }", "query"},
+		{"comment without trailing newline", "# only a comment", "unknown"},
+		{"query body containing the word mutation", "query Foo { recentMutations { id } }", "query"},
+		{"empty", "", "unknown"},
+		{"unrecognized", "fragment Foo on Bar { id }", "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := graphQLOperationKind(tc.body)
+			if got != tc.want {
+				t.Fatalf("graphQLOperationKind(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunWithContext_RetriesQueryOnConnReset(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+		{err: connReset()},
+		{body: `{"data": {}}`},
+	}}
+	client := newTestClient(tripper)
+
+	req := graphql.NewRequest("query Foo { viewer { id } }")
+	if _, err := client.RunWithContext(context.Background(), req); err != nil {
+		t.Fatalf("RunWithContext returned error: %v", err)
+	}
+	if got := tripper.callCount(); got != 3 {
+		t.Fatalf("call count = %d, want 3", got)
+	}
+}
+
+func TestRunWithContext_GivesUpAfterMaxRetries(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+		{err: connReset()},
+		{err: connReset()},
+	}}
+	client := newTestClient(tripper)
+
+	req := graphql.NewRequest("query Foo { viewer { id } }")
+	_, err := client.RunWithContext(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if !errors.Is(err, syscall.ECONNRESET) {
+		t.Fatalf("error chain does not contain ECONNRESET: %v", err)
+	}
+	if got := tripper.callCount(); got != 3 {
+		t.Fatalf("call count = %d, want 3 (1 + 2 retries)", got)
+	}
+}
+
+func TestRunWithContext_DoesNotRetryMutation(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+	}}
+	client := newTestClient(tripper)
+
+	req := graphql.NewRequest("mutation Foo { doThing { id } }")
+	_, err := client.RunWithContext(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := tripper.callCount(); got != 1 {
+		t.Fatalf("call count = %d, want 1 (no retry for mutation)", got)
+	}
+}
+
+func TestRunWithContext_DoesNotRetryNonConnReset(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: errors.New("some other error")},
+	}}
+	client := newTestClient(tripper)
+
+	req := graphql.NewRequest("query Foo { viewer { id } }")
+	_, err := client.RunWithContext(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := tripper.callCount(); got != 1 {
+		t.Fatalf("call count = %d, want 1 (no retry for non-ECONNRESET)", got)
+	}
+}
+
+func TestGenqlient_RetriesQueryOnConnReset(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+		{body: `{"data": {}}`},
+	}}
+	client := newTestClient(tripper)
+
+	req := &genq.Request{Query: "query Foo { viewer { id } }"}
+	resp := &genq.Response{Data: &struct{}{}}
+	if err := client.GenqClient().MakeRequest(context.Background(), req, resp); err != nil {
+		t.Fatalf("MakeRequest returned error: %v", err)
+	}
+	if got := tripper.callCount(); got != 2 {
+		t.Fatalf("call count = %d, want 2", got)
+	}
+}
+
+func TestGenqlient_DoesNotRetryMutation(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+	}}
+	client := newTestClient(tripper)
+
+	req := &genq.Request{Query: "mutation Foo { doThing { id } }"}
+	resp := &genq.Response{Data: &struct{}{}}
+	if err := client.GenqClient().MakeRequest(context.Background(), req, resp); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := tripper.callCount(); got != 1 {
+		t.Fatalf("call count = %d, want 1", got)
 	}
 }

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -13,7 +13,10 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/internal/tracing"
 	"github.com/superfly/fly-go/tokens"
@@ -117,14 +120,8 @@ func (f *Client) _sendRequest(ctx context.Context, method, endpoint string, in, 
 	// timing := instrument.Flaps.Begin()
 	// defer timing.End()
 
-	req, err := f.NewRequest(ctx, method, endpoint, in, headers)
-	if err != nil {
-		tracing.RecordError(span, err, "failed to prepare request")
-		return err
-	}
-	req.Header.Set("User-Agent", f.userAgent)
-
-	resp, err := f.httpClient.Do(req)
+	safeToRetry := method == http.MethodGet
+	resp, err := f.do(ctx, method, endpoint, in, headers, safeToRetry)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to do request")
 		return err
@@ -162,6 +159,49 @@ func (f *Client) _sendRequest(ctx context.Context, method, endpoint string, in, 
 	}
 
 	return nil
+}
+
+// do issues a single HTTP request. When safeToRetry is true, transient network
+// failures are retried.
+//
+// Retry lives here rather than in the shared rehttp transport so in the future
+// we can opt-in other non-GET endpoints that are known to be idempotent.
+func (f *Client) do(ctx context.Context, method, endpoint string, in interface{}, headers map[string][]string, safeToRetry bool) (*http.Response, error) {
+	send := func() (*http.Response, error) {
+		req, err := f.NewRequest(ctx, method, endpoint, in, headers)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", f.userAgent)
+
+		return f.httpClient.Do(req)
+	}
+
+	if !safeToRetry {
+		return send()
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 100 * time.Millisecond
+	b.MaxInterval = 500 * time.Millisecond
+	b.RandomizationFactor = 0.5
+
+	var resp *http.Response
+	err := backoff.Retry(func() error {
+		var err error
+		// Body is closed by the caller of do()
+		resp, err = send() //nolint:bodyclose
+		switch {
+		case err == nil:
+			return nil
+		case errors.Is(err, syscall.ECONNRESET):
+			return err
+		default:
+			return backoff.Permanent(err)
+		}
+	}, backoff.WithContext(backoff.WithMaxRetries(b, 2), ctx))
+
+	return resp, err
 }
 
 func (f *Client) urlFromBaseUrl(pathAndQueryString string) (*url.URL, error) {

--- a/flaps/flaps_test.go
+++ b/flaps/flaps_test.go
@@ -3,8 +3,14 @@ package flaps
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
+	"syscall"
 	"testing"
 )
 
@@ -100,6 +106,126 @@ func assertCookieHeader(w http.ResponseWriter, r *http.Request, want string) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// step describes one scripted RoundTrip outcome. If err is non-nil, the
+// RoundTrip returns (nil, err); otherwise it returns a 200 response whose body
+// is body.
+type step struct {
+	err  error
+	body string
+}
+
+type scriptedTripper struct {
+	mu    sync.Mutex
+	calls int
+	steps []step
+}
+
+func (s *scriptedTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.calls >= len(s.steps) {
+		return nil, fmt.Errorf("scriptedTripper: unexpected call %d", s.calls+1)
+	}
+	st := s.steps[s.calls]
+	s.calls++
+
+	if st.err != nil {
+		return nil, st.err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(st.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (s *scriptedTripper) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func connReset() error {
+	return fmt.Errorf("read tcp: %w", syscall.ECONNRESET)
+}
+
+func newTestFlapsClient(t *testing.T, transport http.RoundTripper) *Client {
+	t.Setenv("FLY_FLAPS_BASE_URL", "http://example.test")
+	client, err := NewWithOptions(context.Background(), NewClientOpts{Transport: transport})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	return client
+}
+
+func TestFlaps_GetRetriesOnConnReset(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+		{err: connReset()},
+		{body: `{}`},
+	}}
+	client := newTestFlapsClient(t, tripper)
+
+	if err := client._sendRequest(context.Background(), http.MethodGet, "/apps", nil, nil, nil); err != nil {
+		t.Fatalf("_sendRequest: %v", err)
+	}
+	if got := tripper.callCount(); got != 3 {
+		t.Fatalf("call count = %d, want 3", got)
+	}
+}
+
+func TestFlaps_GetGivesUpAfterMaxRetries(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+		{err: connReset()},
+		{err: connReset()},
+	}}
+	client := newTestFlapsClient(t, tripper)
+
+	err := client._sendRequest(context.Background(), http.MethodGet, "/apps", nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if !errors.Is(err, syscall.ECONNRESET) {
+		t.Fatalf("error chain does not contain ECONNRESET: %v", err)
+	}
+	if got := tripper.callCount(); got != 3 {
+		t.Fatalf("call count = %d, want 3 (1 + 2 retries)", got)
+	}
+}
+
+func TestFlaps_PostDoesNotRetry(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: connReset()},
+	}}
+	client := newTestFlapsClient(t, tripper)
+
+	err := client._sendRequest(context.Background(), http.MethodPost, "/apps", map[string]string{"name": "x"}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := tripper.callCount(); got != 1 {
+		t.Fatalf("call count = %d, want 1 (no retry for POST)", got)
+	}
+}
+
+func TestFlaps_GetDoesNotRetryNonConnReset(t *testing.T) {
+	tripper := &scriptedTripper{steps: []step{
+		{err: errors.New("some other error")},
+	}}
+	client := newTestFlapsClient(t, tripper)
+
+	err := client._sendRequest(context.Background(), http.MethodGet, "/apps", nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := tripper.callCount(); got != 1 {
+		t.Fatalf("call count = %d, want 1 (no retry for non-ECONNRESET)", got)
+	}
 }
 
 func TestSnakeCase(t *testing.T) {


### PR DESCRIPTION
Make the API clients more robust to transient network issues.

* `fly.Client` and `fly.tracingGenqlientClient` (GraphQL clients): retry GraphQL queries only.
* `flaps.Client`: retry GET requests. We can expand this on an endpoint-by-endpoint basis later.

There's an existing `rehttp` transport in `NewHTTPClient` that applies automatic retry, but it doesn't catch `ECONNRESET`. It also operates at the transport layer and can't reliably distinguish idempotent requests that are safe to retry after a connection reset.

Retry policy: Exponential backoff - 100ms initial, 500ms cap, 50% jitter, max 2 retries