### PR TITLE
Move Fly-Force-Instance-Id to flaps requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -206,7 +206,6 @@ func (t *Transport) setDefaults(opts *ClientOptions) {
 			t.FlyForceRegion = v
 		}
 	}
-
 }
 
 func NewClientFromOptions(opts ClientOptions) *Client {
@@ -373,6 +372,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.FlyForceRegion != "" {
 		req.Header.Set("Fly-Force-Region", t.FlyForceRegion)
 	}
+
 	return t.UnderlyingTransport.RoundTrip(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -167,8 +167,7 @@ type ClientOptions struct {
 	BaseURL          string
 	Logger           Logger
 	EnableDebugTrace *bool
-	FlyForceRegion     *string
-	FlyForceInstanceID *string
+	FlyForceRegion   *string
 	Transport        *Transport
 }
 
@@ -208,13 +207,6 @@ func (t *Transport) setDefaults(opts *ClientOptions) {
 		}
 	}
 
-	if opts.FlyForceInstanceID != nil {
-		t.FlyForceInstanceID = *opts.FlyForceInstanceID
-	} else if t.FlyForceInstanceID == "" {
-		if v := os.Getenv("FLY_FORCE_INSTANCE_ID"); v != "" {
-			t.FlyForceInstanceID = v
-		}
-	}
 }
 
 func NewClientFromOptions(opts ClientOptions) *Client {
@@ -368,7 +360,6 @@ type Transport struct {
 	Tokens              *tokens.Tokens
 	EnableDebugTrace    bool
 	FlyForceRegion      string
-	FlyForceInstanceID  string
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -382,10 +373,6 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.FlyForceRegion != "" {
 		req.Header.Set("Fly-Force-Region", t.FlyForceRegion)
 	}
-	if t.FlyForceInstanceID != "" {
-		req.Header.Set("Fly-Force-Instance-Id", t.FlyForceInstanceID)
-	}
-
 	return t.UnderlyingTransport.RoundTrip(req)
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -83,7 +83,6 @@ func TestTransportSetDefaults_DoesNotOverrideFlyForceRegionFromTransport(t *test
 	}
 }
 
-
 type captureTripper struct {
 	req *http.Request
 }

--- a/client_test.go
+++ b/client_test.go
@@ -83,31 +83,6 @@ func TestTransportSetDefaults_DoesNotOverrideFlyForceRegionFromTransport(t *test
 	}
 }
 
-func TestTransportSetDefaults_DoesNotOverrideFlyForceInstanceIDFromTransport(t *testing.T) {
-	t.Setenv("FLY_FORCE_INSTANCE_ID", "worker-1")
-
-	transport := &Transport{FlyForceInstanceID: "worker-2"}
-	opts := ClientOptions{Transport: transport}
-
-	transport.setDefaults(&opts)
-
-	if transport.FlyForceInstanceID != "worker-2" {
-		t.Fatalf("expected FlyForceInstanceID to remain %q, got %q", "worker-2", transport.FlyForceInstanceID)
-	}
-}
-
-func TestTransportSetDefaults_SetsFlyForceInstanceIDFromEnv(t *testing.T) {
-	t.Setenv("FLY_FORCE_INSTANCE_ID", "worker-1")
-
-	transport := &Transport{}
-	opts := ClientOptions{Transport: transport}
-
-	transport.setDefaults(&opts)
-
-	if transport.FlyForceInstanceID != "worker-1" {
-		t.Fatalf("expected FlyForceInstanceID to be %q, got %q", "worker-1", transport.FlyForceInstanceID)
-	}
-}
 
 type captureTripper struct {
 	req *http.Request
@@ -123,13 +98,12 @@ func (c *captureTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func TestTransportRoundTrip_SetsFlyForceInstanceIDHeader(t *testing.T) {
+func TestTransportRoundTrip_DoesNotSetFlyForceInstanceIDHeader(t *testing.T) {
 	capture := &captureTripper{}
 	transport := &Transport{
 		UnderlyingTransport: capture,
 		UserAgent:           "test/0",
 		Token:               "token",
-		FlyForceInstanceID:  "worker-2",
 	}
 
 	req, err := http.NewRequest(http.MethodGet, "http://example.test", nil)
@@ -143,8 +117,8 @@ func TestTransportRoundTrip_SetsFlyForceInstanceIDHeader(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if got := capture.req.Header.Get("Fly-Force-Instance-Id"); got != "worker-2" {
-		t.Fatalf("Fly-Force-Instance-Id header = %q, want %q", got, "worker-2")
+	if got := capture.req.Header.Get("Fly-Force-Instance-Id"); got != "" {
+		t.Fatalf("Fly-Force-Instance-Id header = %q, want empty", got)
 	}
 }
 

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -29,10 +29,11 @@ import (
 const headerFlyRequestId = "fly-request-id"
 
 type Client struct {
-	baseUrl    *url.URL
-	tokens     *tokens.Tokens
-	httpClient *http.Client
-	userAgent  string
+	baseUrl            *url.URL
+	tokens             *tokens.Tokens
+	httpClient         *http.Client
+	userAgent          string
+	flyForceInstanceID string
 }
 
 type NewClientOpts struct {
@@ -43,6 +44,8 @@ type NewClientOpts struct {
 
 	// optional:
 	Logger fly.Logger
+
+	FlyForceInstanceID string
 
 	// optional, used to construct the underlying HTTP client
 	Transport http.RoundTripper
@@ -84,11 +87,17 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 		userAgent = opts.UserAgent
 	}
 
+	flyForceInstanceID := opts.FlyForceInstanceID
+	if flyForceInstanceID == "" {
+		flyForceInstanceID = os.Getenv("FLY_FORCE_INSTANCE_ID")
+	}
+
 	return &Client{
-		baseUrl:    flapsUrl,
-		tokens:     opts.Tokens,
-		httpClient: httpClient,
-		userAgent:  userAgent,
+		baseUrl:            flapsUrl,
+		tokens:             opts.Tokens,
+		httpClient:         httpClient,
+		userAgent:          userAgent,
+		flyForceInstanceID: flyForceInstanceID,
 	}, nil
 }
 
@@ -242,6 +251,9 @@ func (f *Client) NewRequest(ctx context.Context, method, path string, in interfa
 	req.Header = headers
 	if f.tokens != nil {
 		req.Header.Add("Authorization", f.tokens.FlapsHeader())
+	}
+	if f.flyForceInstanceID != "" {
+		req.Header.Set("Fly-Force-Instance-Id", f.flyForceInstanceID)
 	}
 
 	return req, nil

--- a/flaps/flaps_test.go
+++ b/flaps/flaps_test.go
@@ -122,6 +122,10 @@ type scriptedTripper struct {
 	steps []step
 }
 
+type captureTripper struct {
+	req *http.Request
+}
+
 func (s *scriptedTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -146,6 +150,16 @@ func (s *scriptedTripper) callCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.calls
+}
+
+func (c *captureTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.req = req.Clone(req.Context())
+	c.req.Header = req.Header.Clone()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+	}, nil
 }
 
 func connReset() error {
@@ -210,6 +224,43 @@ func TestFlaps_PostDoesNotRetry(t *testing.T) {
 	}
 	if got := tripper.callCount(); got != 1 {
 		t.Fatalf("call count = %d, want 1 (no retry for POST)", got)
+	}
+}
+
+func TestFlaps_NewRequestSetsFlyForceInstanceIDHeaderFromOpts(t *testing.T) {
+	capture := &captureTripper{}
+	client, err := NewWithOptions(context.Background(), NewClientOpts{
+		Transport:          capture,
+		FlyForceInstanceID: "worker-2",
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error = %v", err)
+	}
+
+	if err := client._sendRequest(context.Background(), http.MethodGet, "/apps", nil, nil, nil); err != nil {
+		t.Fatalf("_sendRequest() error = %v", err)
+	}
+
+	if got := capture.req.Header.Get("Fly-Force-Instance-Id"); got != "worker-2" {
+		t.Fatalf("Fly-Force-Instance-Id header = %q, want %q", got, "worker-2")
+	}
+}
+
+func TestFlaps_NewRequestSetsFlyForceInstanceIDHeaderFromEnv(t *testing.T) {
+	t.Setenv("FLY_FORCE_INSTANCE_ID", "worker-1")
+
+	capture := &captureTripper{}
+	client, err := NewWithOptions(context.Background(), NewClientOpts{Transport: capture})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error = %v", err)
+	}
+
+	if err := client._sendRequest(context.Background(), http.MethodGet, "/apps", nil, nil, nil); err != nil {
+		t.Fatalf("_sendRequest() error = %v", err)
+	}
+
+	if got := capture.req.Header.Get("Fly-Force-Instance-Id"); got != "worker-1" {
+		t.Fatalf("Fly-Force-Instance-Id header = %q, want %q", got, "worker-1")
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop setting `Fly-Force-Instance-Id` on the shared GraphQL transport
- add `FlyForceInstanceID` to `flaps.NewClientOpts`
- set the header only from flaps request creation, with `FLY_FORCE_INSTANCE_ID` env fallback
- update tests to cover GraphQL omission and flaps-only behavior

## Testing
- go test ./...