### PR TITLE
Remove LSVD launch input

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -1126,7 +1126,6 @@ type LaunchMachineInput struct {
 	Name                    string         `toml:"name,omitempty" json:"name,omitempty"`
 	SkipLaunch              bool           `toml:"skip_launch,omitempty" json:"skip_launch,omitempty"`
 	SkipServiceRegistration bool           `toml:"skip_service_registration,omitempty" json:"skip_service_registration,omitempty"`
-	LSVD                    bool           `toml:"lsvd,omitempty" json:"lsvd,omitempty"`
 	SkipSecrets             bool           `json:"skip_secrets"`
 	MinSecretsVersion       *uint64        `json:"min_secrets_version,omitempty"`
 


### PR DESCRIPTION
Remove the retired LSVD field from machine launch input so clients stop sending the unused API parameter.

Related: https://github.com/superfly/flyctl/pull/4911