### PR TITLE
Default the User-Agent to <consumer>/<version> fly-go/<version>

### DIFF
--- a/client.go
+++ b/client.go
@@ -192,7 +192,11 @@ func (t *Transport) setDefaults(opts *ClientOptions) {
 	}
 
 	if t.UserAgent == "" {
-		t.UserAgent = fmt.Sprintf("%s/%s", opts.Name, opts.Version)
+		if opts.Name == "" && opts.Version == "" {
+			t.UserAgent = DefaultUserAgent()
+		} else {
+			t.UserAgent = fmt.Sprintf("%s/%s", opts.Name, opts.Version)
+		}
 	}
 
 	if opts.EnableDebugTrace != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -84,6 +84,28 @@ func TestTransportSetDefaults_DoesNotOverrideFlyForceRegionFromTransport(t *test
 	}
 }
 
+func TestTransportSetDefaults_UserAgentFallsBackToFlyGoVersion(t *testing.T) {
+	transport := &Transport{}
+	opts := ClientOptions{}
+
+	transport.setDefaults(&opts)
+
+	if !strings.HasPrefix(transport.UserAgent, "fly-go/") {
+		t.Fatalf("expected UserAgent to start with %q, got %q", "fly-go/", transport.UserAgent)
+	}
+}
+
+func TestTransportSetDefaults_UserAgentUsesNameAndVersionWhenProvided(t *testing.T) {
+	transport := &Transport{}
+	opts := ClientOptions{Name: "test", Version: "0"}
+
+	transport.setDefaults(&opts)
+
+	if want := "test/0"; transport.UserAgent != want {
+		t.Fatalf("expected UserAgent %q, got %q", want, transport.UserAgent)
+	}
+}
+
 type captureTripper struct {
 	req *http.Request
 }

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -97,7 +97,7 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 	}
 	httpClient.Jar = jar
 
-	userAgent := "fly-go"
+	userAgent := fly.DefaultUserAgent()
 	if opts.UserAgent != "" {
 		userAgent = opts.UserAgent
 	}

--- a/flaps/flaps_test.go
+++ b/flaps/flaps_test.go
@@ -31,6 +31,30 @@ func TestNewWithOptionsSetsCookieJar(t *testing.T) {
 	}
 }
 
+func TestNewWithOptions_UserAgentFallsBackToFlyGoVersion(t *testing.T) {
+	t.Setenv("FLY_FLAPS_BASE_URL", "http://example.com")
+
+	client, err := NewWithOptions(context.Background(), NewClientOpts{})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error = %v", err)
+	}
+	if !strings.HasPrefix(client.userAgent, "fly-go/") {
+		t.Fatalf("expected userAgent to start with %q, got %q", "fly-go/", client.userAgent)
+	}
+}
+
+func TestNewWithOptions_UserAgentUsesOptsWhenProvided(t *testing.T) {
+	t.Setenv("FLY_FLAPS_BASE_URL", "http://example.com")
+
+	client, err := NewWithOptions(context.Background(), NewClientOpts{UserAgent: "flyctl/1.2.3"})
+	if err != nil {
+		t.Fatalf("NewWithOptions() error = %v", err)
+	}
+	if want := "flyctl/1.2.3"; client.userAgent != want {
+		t.Fatalf("expected userAgent %q, got %q", want, client.userAgent)
+	}
+}
+
 func TestFlapsClientPersistsPathScopedCookiesPerApp(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/version.go
+++ b/version.go
@@ -51,6 +51,10 @@ func DefaultUserAgent() string {
 		return "fly-go/unknown"
 	}
 
+	return defaultUserAgent(info)
+}
+
+func defaultUserAgent(info *debug.BuildInfo) string {
 	version := flyGoVersion(info)
 	if info.Main.Path == modulePath {
 		return "fly-go/" + version

--- a/version.go
+++ b/version.go
@@ -1,25 +1,28 @@
 package fly
 
-import "runtime/debug"
+import (
+	"fmt"
+	"path"
+	"runtime/debug"
+)
 
 const modulePath = "github.com/superfly/fly-go"
 
-// moduleVersion returns the version of this module as resolved in the
-// consuming binary (e.g. "v0.7.0"), or "unknown" if it can't be determined -
-// for example when built without module support, or when this module is
-// replaced with a local filesystem path.
-func moduleVersion() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
+func versionOrUnknown(v string) string {
+	if v == "" {
 		return "unknown"
 	}
 
-	if info.Main.Path == modulePath {
-		if info.Main.Version != "" {
-			return info.Main.Version
-		}
+	return v
+}
 
-		return "unknown"
+// flyGoVersion returns the version of this module as resolved in the
+// consuming binary (e.g. "v0.7.0"), or "unknown" if it can't be determined -
+// for example when built without module support, or when this module is
+// replaced with a local filesystem path.
+func flyGoVersion(info *debug.BuildInfo) string {
+	if info.Main.Path == modulePath {
+		return versionOrUnknown(info.Main.Version)
 	}
 
 	for _, dep := range info.Deps {
@@ -29,18 +32,34 @@ func moduleVersion() string {
 		if dep.Replace != nil {
 			dep = dep.Replace
 		}
-		if dep.Version != "" {
-			return dep.Version
-		}
 
-		return "unknown"
+		return versionOrUnknown(dep.Version)
 	}
 
 	return "unknown"
 }
 
 // DefaultUserAgent returns the User-Agent clients should fall back to when
-// no caller-supplied name/version is available: "fly-go/<version>".
+// no caller-supplied name/version is available. It identifies the consuming
+// binary using its main module's build info, with fly-go's own resolved
+// version appended as a suffix, e.g. "flyctl/v1.2.3 fly-go/v0.7.0". If
+// fly-go is itself the main module (running its own tests/binaries), it
+// returns just "fly-go/<version>".
 func DefaultUserAgent() string {
-	return "fly-go/" + moduleVersion()
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "fly-go/unknown"
+	}
+
+	version := flyGoVersion(info)
+	if info.Main.Path == modulePath {
+		return "fly-go/" + version
+	}
+
+	name := "unknown"
+	if info.Main.Path != "" {
+		name = path.Base(info.Main.Path)
+	}
+
+	return fmt.Sprintf("%s/%s fly-go/%s", name, versionOrUnknown(info.Main.Version), version)
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,46 @@
+package fly
+
+import "runtime/debug"
+
+const modulePath = "github.com/superfly/fly-go"
+
+// moduleVersion returns the version of this module as resolved in the
+// consuming binary (e.g. "v0.7.0"), or "unknown" if it can't be determined -
+// for example when built without module support, or when this module is
+// replaced with a local filesystem path.
+func moduleVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+
+	if info.Main.Path == modulePath {
+		if info.Main.Version != "" {
+			return info.Main.Version
+		}
+
+		return "unknown"
+	}
+
+	for _, dep := range info.Deps {
+		if dep.Path != modulePath {
+			continue
+		}
+		if dep.Replace != nil {
+			dep = dep.Replace
+		}
+		if dep.Version != "" {
+			return dep.Version
+		}
+
+		return "unknown"
+	}
+
+	return "unknown"
+}
+
+// DefaultUserAgent returns the User-Agent clients should fall back to when
+// no caller-supplied name/version is available: "fly-go/<version>".
+func DefaultUserAgent() string {
+	return "fly-go/" + moduleVersion()
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,185 @@
+package fly
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestVersionOrUnknown(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "unknown"},
+		{"v1.2.3", "v1.2.3"},
+		{"(devel)", "(devel)"},
+	}
+
+	for _, c := range cases {
+		if got := versionOrUnknown(c.in); got != c.want {
+			t.Errorf("versionOrUnknown(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFlyGoVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "fly-go is the main module",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "v0.7.0"},
+			},
+			want: "v0.7.0",
+		},
+		{
+			name: "fly-go is the main module with no version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: ""},
+			},
+			want: "unknown",
+		},
+		{
+			name: "fly-go is a regular dependency",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{Path: "github.com/some/other-dep", Version: "v9.9.9"},
+					{Path: modulePath, Version: "v0.7.0"},
+				},
+			},
+			want: "v0.7.0",
+		},
+		{
+			name: "fly-go is replaced with a local filesystem path",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v0.0.0-00010101000000-000000000000",
+						Replace: &debug.Module{Path: "../fly-go", Version: ""},
+					},
+				},
+			},
+			want: "unknown",
+		},
+		{
+			name: "fly-go is replaced with another pinned module version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v0.0.0-00010101000000-000000000000",
+						Replace: &debug.Module{Path: "github.com/example/fly-go-fork", Version: "v0.1.0"},
+					},
+				},
+			},
+			want: "v0.1.0",
+		},
+		{
+			name: "fly-go is not present at all",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{Path: "github.com/some/other-dep", Version: "v9.9.9"},
+				},
+			},
+			want: "unknown",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := flyGoVersion(c.info); got != c.want {
+				t.Errorf("flyGoVersion() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDefaultUserAgentFromBuildInfo(t *testing.T) {
+	cases := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "fly-go is the main module",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "v0.7.0"},
+			},
+			want: "fly-go/v0.7.0",
+		},
+		{
+			name: "fly-go is the main module in devel mode",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: ""},
+			},
+			want: "fly-go/unknown",
+		},
+		{
+			name: "consumer with fly-go as a dependency",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{Path: modulePath, Version: "v0.7.0"},
+				},
+			},
+			want: "flyctl/v1.2.3 fly-go/v0.7.0",
+		},
+		{
+			name: "consumer built in devel mode with locally-replaced fly-go",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl", Version: ""},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v0.0.0-00010101000000-000000000000",
+						Replace: &debug.Module{Path: "../fly-go", Version: ""},
+					},
+				},
+			},
+			want: "flyctl/unknown fly-go/unknown",
+		},
+		{
+			name: "consumer with a nested module path",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/superfly/flyctl/internal/tool", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{Path: modulePath, Version: "v0.7.0"},
+				},
+			},
+			want: "tool/v1.2.3 fly-go/v0.7.0",
+		},
+		{
+			name: "consumer with no main path",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "", Version: ""},
+			},
+			want: "unknown/unknown fly-go/unknown",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := defaultUserAgent(c.info); got != c.want {
+				t.Errorf("defaultUserAgent() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDefaultUserAgent(t *testing.T) {
+	// Running as fly-go's own test binary, fly-go is the main module, so the
+	// real build info should collapse to a bare "fly-go/<version>".
+	ua := DefaultUserAgent()
+	if !strings.HasPrefix(ua, "fly-go/") {
+		t.Fatalf("DefaultUserAgent() = %q, want it to start with %q", ua, "fly-go/")
+	}
+}


### PR DESCRIPTION
Both the GraphQL client and the flaps client fall back to an uninformative User-Agent when a caller doesn't supply a name/version — the GraphQL client sends a bare `/`, and flaps sends the unversioned literal `fly-go`. This makes it hard to tell which application (and which fly-go version) is talking to the API when the embedding application hasn't wired up its own name/version.

## Context

fly-go is a library, so it can't bake its own version in at build time (no main package, no `-ldflags`). The only way for it to know its own version — or the identity of the binary it's embedded in — is to read it back out of the consuming binary's module info at runtime.

## Details

- Added `version.go` with `DefaultUserAgent()`, which uses `runtime/debug.ReadBuildInfo()` to derive:
  - the consuming binary's identity from `info.Main` (module path basename + version), and
  - fly-go's own resolved version, found via `info.Deps` (handling the `replace`-directive case) or `info.Main` when fly-go itself is the main module.

  The result is `<consumer>/<version> fly-go/<fly-go-version>`, e.g. `flyctl/v1.2.3 fly-go/v0.7.0`. When fly-go is itself the main module (its own tests/binaries), it collapses to just `fly-go/<version>`. Any piece that can't be resolved falls back to `unknown`.
- `client.go`: `Transport.setDefaults` now uses `DefaultUserAgent()` when both `ClientOptions.Name` and `Version` are empty.
- `flaps/flaps.go`: the default `userAgent` is now `fly.DefaultUserAgent()` instead of the hardcoded `"fly-go"` literal.
- Added unit tests for the version-resolution logic (`version_test.go`, covering the main-module, dependency, and local-replace branches via synthetic build info), plus integration tests on `Transport.setDefaults` and `flaps.NewWithOptions` confirming the default and the explicit-name/version paths both behave correctly.