### PR TITLE
Bump github.com/superfly/client-signals to v0.3.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters:
           - github.com/Khan/genqlient
           - github.com/google/go-querystring
           - github.com/PuerkitoBio/rehttp
-          - github.com/superfly/client-signals
+          - github.com/superfly/client-signals/go
           - github.com/superfly/graphql
           - github.com/superfly/macaroon
           - github.com/superfly/macaroon/flyio

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 	_ "github.com/Khan/genqlient/generate"
 	genq "github.com/Khan/genqlient/graphql"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/superfly/client-signals"
+	"github.com/superfly/client-signals/go"
 	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/graphql"
 	"go.opentelemetry.io/otel"

--- a/client_test.go
+++ b/client_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	genq "github.com/Khan/genqlient/graphql"
-	"github.com/superfly/client-signals"
+	"github.com/superfly/client-signals/go"
 	"github.com/superfly/graphql"
 )
 

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/superfly/client-signals"
+	"github.com/superfly/client-signals/go"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/internal/tracing"
 	"github.com/superfly/fly-go/tokens"

--- a/flaps/flaps_test.go
+++ b/flaps/flaps_test.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/superfly/client-signals"
+	"github.com/superfly/client-signals/go"
 )
 
 func TestNewWithOptionsSetsCookieJar(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/superfly/client-signals v0.2.0
+	github.com/superfly/client-signals/go v0.3.0
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/macaroon v0.3.0
 	go.opentelemetry.io/otel v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/superfly/client-signals v0.2.0 h1:ecwb3sCWwZ55+gpinSi/3yl4/OSBAsqYpmMUxsbbNaU=
-github.com/superfly/client-signals v0.2.0/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+github.com/superfly/client-signals/go v0.3.0 h1:UegKdBgPCYn5FqSGdxHUIeyLTAGWnd0kYxlioARw4LY=
+github.com/superfly/client-signals/go v0.3.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/macaroon v0.3.0 h1:tdRq5VqBCNJIlvYByZZ3bGDOKX/v0llQM/Ljd27DbU8=


### PR DESCRIPTION
Bumps `github.com/superfly/client-signals` from v0.2.0 to v0.3.0.

## Context

The Go module in `client-signals` moved into a `go/` subdirectory as of v0.3.0, so its import path changes from `github.com/superfly/client-signals` to `github.com/superfly/client-signals/go`. Consuming that version required upstream to backfill a `go/v0.3.0` git tag matching Go's nested-module versioning convention, tracked in [superfly/client-signals#2](https://github.com/superfly/client-signals/issues/2) (now fixed).

## Details

Updated the import path everywhere it's used (`client.go`, `client_test.go`, `flaps/flaps.go`, `flaps/flaps_test.go`) and the `gomodguard` allowlist in `.golangci.yml` to match the new module path.