### PR TITLE
Fix golangci-lint findings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9.3.0
         with:
           # Keep golangci-lint version insync with .pre-commit-config.yaml
-          version: v2.11.3
+          version: v2.12.2
 
   test:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   # The trick is to run github action only for "manual" hook stage
   - repo: https://github.com/golangci/golangci-lint
     # Keep golangci-lint version in sync with .github/workflows/checks.yml
-    rev: v2.11.3
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
         stages: [pre-commit]

--- a/cli_session.go
+++ b/cli_session.go
@@ -59,10 +59,13 @@ func StartCLISession(sessionName string, args map[string]any) (CLISession, error
 func RedeemCLISessionToken(ctx context.Context, id, code, codeVerifier string) (CLISession, error) {
 	var result CLISession
 
-	postData, _ := json.Marshal(map[string]string{
+	postData, err := json.Marshal(map[string]string{
 		"code":          code,
 		"code_verifier": codeVerifier,
 	})
+	if err != nil {
+		return result, fmt.Errorf("marshal CLI session redemption request: %w", err)
+	}
 
 	url := fmt.Sprintf("%s/api/v1/cli_sessions/%s/redeem", baseURL, id)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(postData))
@@ -75,13 +78,14 @@ func RedeemCLISessionToken(ctx context.Context, id, code, codeVerifier string) (
 	if err != nil {
 		return result, err
 	}
-	defer res.Body.Close() //skipcq: GO-S2307
+	defer res.Body.Close() // skipcq: GO-S2307
 
 	switch res.StatusCode {
 	case http.StatusOK:
 		if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
 			return result, fmt.Errorf("failed to decode session, please try again: %w", err)
 		}
+
 		return result, nil
 	case http.StatusNotFound:
 		return result, ErrNotFound
@@ -92,6 +96,7 @@ func RedeemCLISessionToken(ctx context.Context, id, code, codeVerifier string) (
 		if err := json.NewDecoder(res.Body).Decode(&apiErr); err == nil && apiErr.Error != "" {
 			return result, fmt.Errorf("failed to redeem login code: %s", apiErr.Error)
 		}
+
 		return result, ErrUnknown
 	}
 }

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -169,6 +169,7 @@ func (t *Tokens) Equal(other *Tokens) bool {
 }
 
 func (t *Tokens) equalUnlocked(other *Tokens) bool {
+	//nolint:govet // Go vet's inline analyzer cannot handle generic type inference.
 	return slices.Equal(t.macaroons, other.macaroons) && slices.Equal(t.oauths, other.oauths) && t.fromFile == other.fromFile
 }
 
@@ -287,6 +288,7 @@ func (t *Tokens) pruneBadMacaroons(options *updateOptions) bool {
 		}
 	}
 
+	//nolint:govet // Go vet's inline analyzer cannot handle generic type inference.
 	t.macaroons = slices.DeleteFunc(t.macaroons, func(tok string) bool {
 		m, ok := parsed[tok]
 		if !ok {


### PR DESCRIPTION
Fix the current golangci-lint findings.

The CLI-session redemption request now returns JSON encoding errors, and the two generic `slices` calls receive targeted `govet` suppressions for the Go vet generic-inference limitation.

Validation: `go test ./tokens` and `golangci-lint run ./...`.