### PR TITLE
Replace node(id:) lookup with volume(id:) query

### DIFF
--- a/resource_volumes.go
+++ b/resource_volumes.go
@@ -7,7 +7,7 @@ import (
 func (c *Client) GetAppNameFromVolume(ctx context.Context, volID string) (*string, error) {
 	query := `
 query($id: ID!) {
-	volume: node(id: $id) {
+	volume: volume(id: $id) {
 		... on Volume {
 			app {
 				name
@@ -33,7 +33,7 @@ query($id: ID!) {
 func (c *Client) GetAppNameStateFromVolume(ctx context.Context, volID string) (*string, *string, error) {
 	query := `
 query GetAppNameStateFromVolume($id: ID!) {
-	volume: node(id: $id) {
+	volume: volume(id: $id) {
 		... on Volume {
 			app {
 				name
@@ -60,7 +60,7 @@ query GetAppNameStateFromVolume($id: ID!) {
 func (c *Client) GetSnapshotsFromVolume(ctx context.Context, volID string) ([]VolumeSnapshot, error) {
 	query := `
 query GetSnapshotsFromVolume($id: ID!) {
-	volume: node(id: $id) {
+	volume: volume(id: $id) {
 		... on Volume {
 			snapshots {
 				nodes {


### PR DESCRIPTION
**Why**
[This commit in web](https://github.com/superfly/web/commit/712018270ecd73efe4be53d4e709a503e5ad99be) gated the Relay node(id:) field behind private_api, which broke GetAppNameFromVolume, GetAppNameStateFromVolume, and GetSnapshotsFromVolume — and with them fly postgres create --fork-from, fly volumes update, and the snapshots commands without -a. 

**What**
Switch to the still-public volume(id:) root query; response shape is unchanged via the alias.