### PR TITLE
Add MPGAvailable to the Region struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -619,6 +619,7 @@ type Region struct {
 	Deprecated       bool      `json:"deprecated"`
 	Capacity         int64     `json:"capacity"`
 	GeoRegion        GeoRegion `json:"geo_region"`
+	MPGAvailable     bool      `json:"mpg_available"`
 }
 
 type Release struct {


### PR DESCRIPTION
## What

The platform regions data now includes `mpg_available`, indicating whether Managed Postgres is available in each region. This PR adds the field to Region.

## Related to
- https://github.com/superfly/mpg/issues/306

## Related PRs
- https://github.com/superfly/corro-config/pull/151
- https://github.com/superfly/consul-data/pull/160