### PR TITLE
Bump client-signals to v0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/superfly/client-signals/go v0.4.3
+	github.com/superfly/client-signals/go v0.4.4
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/macaroon v0.3.0
 	go.opentelemetry.io/otel v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/superfly/client-signals/go v0.4.3 h1:Z39/55nx54TmzwbKyyG5BEVg4L28fhqYAJ0nI+bxY8M=
-github.com/superfly/client-signals/go v0.4.3/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
+github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
+github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/macaroon v0.3.0 h1:tdRq5VqBCNJIlvYByZZ3bGDOKX/v0llQM/Ljd27DbU8=


### PR DESCRIPTION
Bumps `github.com/superfly/client-signals/go` from v0.4.3 to v0.4.4.

Dependency pin only — no code changes. v0.4.4 over v0.4.3 is release plumbing
(npm/Hex publishing from release tags, publishing the JS package under the fly
scope, then disabling npm publishing, plus a grok agent marker); the Go module
hash is unchanged.

This brings fly-go in line with the other consumers — flyctl, nomad-firecracker,
ui-ex and sprites-api are already on v0.4.4.

`go build ./...`, `go test ./...`, `go vet ./...` and `golangci-lint run ./...`
all clean.