### PR TITLE
Remove the GPU spot bid price and the spot-price restart policy

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -367,7 +367,6 @@ var (
 	MachineRestartPolicyNo        MachineRestartPolicy = "no"
 	MachineRestartPolicyOnFailure MachineRestartPolicy = "on-failure"
 	MachineRestartPolicyAlways    MachineRestartPolicy = "always"
-	MachineRestartPolicySpotPrice MachineRestartPolicy = "spot-price"
 )
 
 type MachinePersistRootfs string
@@ -445,12 +444,9 @@ type MachineRestart struct {
 	// * no - Never try to restart a Machine automatically when its main process exits, whether that’s on purpose or on a crash.
 	// * always - Always restart a Machine automatically and never let it enter a stopped state, even when the main process exits cleanly.
 	// * on-failure - Try up to MaxRetries times to automatically restart the Machine if it exits with a non-zero exit code. Default when no explicit policy is set, and for Machines with schedules.
-	// * spot-price - Starts the Machine only when there is capacity and the spot price is less than or equal to the bid price.
-	Policy MachineRestartPolicy `toml:"policy,omitempty" json:"policy,omitempty" enums:"no,always,on-failure,spot-price"`
+	Policy MachineRestartPolicy `toml:"policy,omitempty" json:"policy,omitempty" enums:"no,always,on-failure"`
 	// When policy is on-failure, the maximum number of times to attempt to restart the Machine before letting it stop.
 	MaxRetries int `toml:"max_retries,omitempty" json:"max_retries,omitempty"`
-	// GPU bid price for spot Machines.
-	GPUBidPrice float32 `toml:"gpu_bid_price,omitempty" json:"gpu_bid_price,omitempty"`
 }
 
 type MachineMount struct {
@@ -964,8 +960,7 @@ type ContainerConfig struct {
 	// Files are files that will be written to the container file system.
 	Files []*File `toml:"files,omitempty" json:"files,omitempty"`
 
-	// Restart is used to define the restart policy for the container. NOTE: spot-price is not
-	// supported for containers.
+	// Restart is used to define the restart policy for the container.
 	Restart *MachineRestart `toml:"restart,omitempty" json:"restart,omitempty"`
 
 	// Stop is used to define the signal and timeout for stopping the container.


### PR DESCRIPTION
Removes `MachineRestart.GPUBidPrice` and the `spot-price` restart policy, both of which are dead now that GPU Machines are no longer offered.

## Context

`GPUBidPrice` was the GPU-era spot bid. Spot Machines are now driven by `spot.max_price_fraction`, which the API validates against the regional spot price at create time, so nothing reads the bid any more — it has no Go consumer anywhere.

The `spot-price` restart policy goes with it. The API removed the matching enum value (its schema now reserves both the field number and the name), so a client sending `policy = "spot-price"` can only produce a request that gets rejected.

**Spot Machines themselves are unaffected.** They are a separate, live feature with their own config and their own regional pricing; this change only removes the GPU-era bid and the policy that compared against it.

## Details

This is a breaking change for anyone referencing `GPUBidPrice` or `MachineRestartPolicySpotPrice` in Go, and `gpu_bid_price` will drop out of the generated Machines API spec, which is built from these structs.

`fly.toml` compatibility is soft: TOML decoding ignores unknown keys, so a stale `gpu_bid_price` under `[[restart]]` is simply dropped on deploy. `fly config validate` will start reporting it as an unrecognized key, which seems like the right outcome for a setting that has done nothing since GPUs went away.