### PR TITLE
Fix the nil dereference in flaps.AppNameAvailable

### DIFF
--- a/flaps/flaps_apps.go
+++ b/flaps/flaps_apps.go
@@ -2,7 +2,7 @@ package flaps
 
 import (
 	"context"
-	"log"
+	"errors"
 	"net/http"
 	"net/url"
 	"slices"
@@ -89,22 +89,34 @@ func (f *Client) DeleteApp(ctx context.Context, name string) error {
 	return f._sendRequest(ctx, http.MethodDelete, "/apps/"+name, nil, nil, nil)
 }
 
-func (f *Client) AppNameAvailable(ctx context.Context, name string) (ok bool, err error) {
-	_, err = f.GetApp(ctx, name)
-	log.Println(err.Error())
-	switch {
-	case err == nil:
-		// app was found
-		return
-	case err.Error() == "unauthorized":
-		// app exists, but in an org we do not have access to
-		err = nil
-	case err.Error() == "app not found":
-		ok = true
-		err = nil
+// AppNameAvailable reports whether name is free to use for a new app.
+//
+// App names are a single global namespace, so a name can be taken by an app
+// this client cannot see: the API answers that lookup with a 401 rather than
+// admitting the app exists, and it counts as taken just as much as one we can
+// read. Only a 404 means the name is free. Any other failure is returned as-is,
+// with ok false, because it says nothing either way about the name.
+func (f *Client) AppNameAvailable(ctx context.Context, name string) (bool, error) {
+	_, err := f.GetApp(ctx, name)
+	if err == nil {
+		// The app exists and we can see it.
+		return false, nil
 	}
 
-	return
+	// Classify on the status code the API sets, not on the prose it wraps: the
+	// message is not part of the API and can be reworded without warning.
+	var ferr *FlapsError
+	if errors.As(err, &ferr) {
+		switch ferr.ResponseStatusCode {
+		case http.StatusUnauthorized:
+			// The app exists, in an org we do not have access to.
+			return false, nil
+		case http.StatusNotFound:
+			return true, nil
+		}
+	}
+
+	return false, err
 }
 
 func (f *Client) WaitForApp(ctx context.Context, name string) error {

--- a/flaps/flaps_apps_test.go
+++ b/flaps/flaps_apps_test.go
@@ -1,0 +1,79 @@
+package flaps
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// statusRoundTripper answers every request with a canned status and body,
+// which is all AppNameAvailable looks at.
+type statusRoundTripper struct {
+	status int
+	body   string
+}
+
+func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.status,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestAppNameAvailable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		status  int
+		body    string
+		wantOK  bool
+		wantErr bool
+	}{
+		{
+			// The regression case: the app is ours and GetApp succeeds, so
+			// there is no error to classify.
+			name:   "app exists",
+			status: http.StatusOK,
+			body:   `{"id":"app-id","name":"taken-app","status":"deployed"}`,
+		},
+		{
+			// The app exists in an org we cannot see into. Still taken.
+			name:   "unauthorized",
+			status: http.StatusUnauthorized,
+			body:   `{"error":"unauthorized"}`,
+		},
+		{
+			name:   "not found",
+			status: http.StatusNotFound,
+			body:   `{"error":"app not found"}`,
+			wantOK: true,
+		},
+		{
+			// Anything else says nothing about the name, so it propagates.
+			name:    "server error",
+			status:  http.StatusInternalServerError,
+			body:    `{"error":"something went wrong"}`,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, &statusRoundTripper{status: tc.status, body: tc.body})
+
+			ok, err := client.AppNameAvailable(context.Background(), "some-app")
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("AppNameAvailable() error = nil, want non-nil")
+				}
+			} else if err != nil {
+				t.Fatalf("AppNameAvailable() error = %v, want nil", err)
+			}
+
+			if ok != tc.wantOK {
+				t.Fatalf("AppNameAvailable() ok = %v, want %v", ok, tc.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #280.

`AppNameAvailable` dereferenced `GetApp`'s error before checking whether there
was one, so the one input it exists to report on — a name that is already taken
— panicked instead of answering. The offending line was a stray
`log.Println(err.Error())` sitting directly above the switch whose first case
handles a nil error.

Removing it fixes the panic and takes the library's writes to the standard
logger with it; in a CLI that output landed in the user's terminal.

The two remaining branches classified the failure by comparing `err.Error()`
against the exact strings `"unauthorized"` and `"app not found"`. Those are the
API's current prose, not part of its contract, and can be reworded without
warning. This classifies on `FlapsError.ResponseStatusCode` instead — 401 and
404 carry the same information and are what the API actually promises. The
semantics are unchanged: a visible app and a 401 both mean the name is taken, a
404 means it is free, anything else propagates with `ok` false.

A couple of judgement calls worth flagging for review:

- **`errors.As` rather than a new sentinel.** `ErrFlapsNotFound` already exists
  and `errors.Is` would cover the 404, but there is no 401 equivalent. Rather
  than add one — a new exported symbol, and only for internal use here — both
  codes are read off one `errors.As` into `*FlapsError` and handled in a single
  switch. `WaitForApp` just below does the same status-code check with a bare
  type assertion; `errors.As` is used here so a wrapped error still matches.
- **No prose fallback.** The old string comparisons are gone rather than kept
  as a fallback for errors that are not `*FlapsError`. `_sendRequest` is what
  produces these errors and it always produces a `*FlapsError` for a non-2xx
  response, so a fallback would be unreachable. (`IsNameTakenError` keeps its
  legacy-prose fallback for a concrete reason — apps created over GraphQL,
  older servers — that does not apply here.)

Adds the test the function never had, which is the other reason a panic on the
primary path went unnoticed. It covers all four paths — app visible, 401, 404,
500 — over a `RoundTripper` returning a canned status. The app-visible case is
a real regression test: it fails against the old code with the panic itself.

`go build ./...` and `go test ./flaps/...` are clean.