### PR TITLE
Report an app held by another org as taken, not as an error

### DIFF
--- a/flaps/flaps_apps.go
+++ b/flaps/flaps_apps.go
@@ -97,8 +97,9 @@ func (f *Client) DeleteApp(ctx context.Context, name string) error {
 // comes back as a 403 and counts as taken just as much as an app we can read.
 // Only a 404 means the name is free.
 //
-// Any other failure is returned as-is, with ok false, because it says nothing
-// either way about the name. That includes a 401, which is what an
+// Any other failure is returned as-is, alongside a false that means "not
+// available" rather than "taken", because such a failure says nothing either
+// way about the name. That includes a 401, which is what an
 // unauthenticated or unusable token gets: reporting it as "taken" would tell
 // the caller their name is in use when the truth is that nobody asked the
 // question successfully.

--- a/flaps/flaps_apps.go
+++ b/flaps/flaps_apps.go
@@ -92,10 +92,16 @@ func (f *Client) DeleteApp(ctx context.Context, name string) error {
 // AppNameAvailable reports whether name is free to use for a new app.
 //
 // App names are a single global namespace, so a name can be taken by an app
-// this client cannot see: the API answers that lookup with a 401 rather than
-// admitting the app exists, and it counts as taken just as much as one we can
-// read. Only a 404 means the name is free. Any other failure is returned as-is,
-// with ok false, because it says nothing either way about the name.
+// this client cannot see. The API does not hide that: it looks the name up
+// globally and then refuses the read, so a name held by another organization
+// comes back as a 403 and counts as taken just as much as an app we can read.
+// Only a 404 means the name is free.
+//
+// Any other failure is returned as-is, with ok false, because it says nothing
+// either way about the name. That includes a 401, which is what an
+// unauthenticated or unusable token gets: reporting it as "taken" would tell
+// the caller their name is in use when the truth is that nobody asked the
+// question successfully.
 func (f *Client) AppNameAvailable(ctx context.Context, name string) (bool, error) {
 	_, err := f.GetApp(ctx, name)
 	if err == nil {
@@ -108,7 +114,7 @@ func (f *Client) AppNameAvailable(ctx context.Context, name string) (bool, error
 	var ferr *FlapsError
 	if errors.As(err, &ferr) {
 		switch ferr.ResponseStatusCode {
-		case http.StatusUnauthorized:
+		case http.StatusForbidden:
 			// The app exists, in an org we do not have access to.
 			return false, nil
 		case http.StatusNotFound:

--- a/flaps/flaps_apps_test.go
+++ b/flaps/flaps_apps_test.go
@@ -39,10 +39,20 @@ func TestAppNameAvailable(t *testing.T) {
 			body:   `{"id":"app-id","name":"taken-app","status":"deployed"}`,
 		},
 		{
-			// The app exists in an org we cannot see into. Still taken.
-			name:   "unauthorized",
-			status: http.StatusUnauthorized,
+			// The app exists in an org we cannot see into. The API looks the
+			// name up globally and then refuses the read, so this is a 403 —
+			// and the name is taken.
+			name:   "forbidden",
+			status: http.StatusForbidden,
 			body:   `{"error":"unauthorized"}`,
+		},
+		{
+			// Nobody asked the question successfully, so this says nothing
+			// about the name and must not be reported as taken.
+			name:    "unauthenticated",
+			status:  http.StatusUnauthorized,
+			body:    `{"error":"invalid token"}`,
+			wantErr: true,
 		},
 		{
 			name:   "not found",


### PR DESCRIPTION
Follow-up to #281, which I got wrong in one place.

`flaps.AppNameAvailable` treats "the app exists, but in an org you cannot see"
as a **401**. That is the wrong status. The Machines API looks an app name up
globally and then refuses the read, so a name held by an organization your token
does not cover comes back as a **403**; 401 is what a token it cannot use at all
gets.

The tell is in the code #281 replaced: the old branch matched the error text
`"unauthorized"`, and that string is the body the API sends *with* the 403. I
swapped prose matching for status matching and picked the status the prose
looked like rather than the one it came with — which is a good argument for the
change in #281 and a bad advertisement for how I made it. `AppNameAvailable`
still has no callers, so the regression never reached one.

This matches on 403 instead. A 401 now propagates as the error it is rather than
being reported as a taken name: an unauthenticated caller has not learned
anything about the name, and telling them it is in use is worse than telling
them the request failed. That is the one judgement call here — if a 401 does
reach this path in some deployment I have not accounted for, say so and I will
match both.

Tests cover all five paths now: app visible, 403, 401, 404 and 500.

I have not been able to confirm the statuses against the live API from this
machine (no token to hand), so the reasoning above is from the API's behaviour
rather than an observed response. Worth a second pair of eyes from someone who
can check.

Context for why this matters now: superfly/flyctl#5104 moves `fly launch`'s
app-name check onto this function, and the foreign-app case is exactly the one
the GraphQL query it replaces gets right.