### PR TITLE
Expose the target state selected for Machine updates

### DIFF
--- a/machine_types.go
+++ b/machine_types.go
@@ -47,7 +47,7 @@ type Machine struct {
 	ID    string `toml:"id,omitempty" json:"id,omitempty"`
 	Name  string `toml:"name,omitempty" json:"name,omitempty"`
 	State string `toml:"state,omitempty" json:"state,omitempty"`
-	// TargetState is the terminal state selected for an update request.
+	// TargetState is the state selected for an update request.
 	TargetState string          `toml:"target_state,omitempty" json:"target_state,omitempty"`
 	Region      string          `toml:"region,omitempty" json:"region,omitempty"`
 	ImageRef    MachineImageRef `toml:"image_ref,omitempty" json:"image_ref"`

--- a/machine_types.go
+++ b/machine_types.go
@@ -47,7 +47,7 @@ type Machine struct {
 	ID    string `toml:"id,omitempty" json:"id,omitempty"`
 	Name  string `toml:"name,omitempty" json:"name,omitempty"`
 	State string `toml:"state,omitempty" json:"state,omitempty"`
-	// TargetState is the state selected for an update request.
+	// TargetState is the state selected for an update response.
 	TargetState string          `toml:"target_state,omitempty" json:"target_state,omitempty"`
 	Region      string          `toml:"region,omitempty" json:"region,omitempty"`
 	ImageRef    MachineImageRef `toml:"image_ref,omitempty" json:"image_ref"`

--- a/machine_types.go
+++ b/machine_types.go
@@ -44,11 +44,13 @@ var (
 )
 
 type Machine struct {
-	ID       string          `toml:"id,omitempty" json:"id,omitempty"`
-	Name     string          `toml:"name,omitempty" json:"name,omitempty"`
-	State    string          `toml:"state,omitempty" json:"state,omitempty"`
-	Region   string          `toml:"region,omitempty" json:"region,omitempty"`
-	ImageRef MachineImageRef `toml:"image_ref,omitempty" json:"image_ref"`
+	ID    string `toml:"id,omitempty" json:"id,omitempty"`
+	Name  string `toml:"name,omitempty" json:"name,omitempty"`
+	State string `toml:"state,omitempty" json:"state,omitempty"`
+	// TargetState is the terminal state selected for an update request.
+	TargetState string          `toml:"target_state,omitempty" json:"target_state,omitempty"`
+	Region      string          `toml:"region,omitempty" json:"region,omitempty"`
+	ImageRef    MachineImageRef `toml:"image_ref,omitempty" json:"image_ref"`
 	// InstanceID is unique for each version of the machine
 	InstanceID string `toml:"instance_id,omitempty" json:"instance_id,omitempty"`
 	Version    string `toml:"version,omitempty" json:"version,omitempty"`

--- a/machine_types_test.go
+++ b/machine_types_test.go
@@ -7,6 +7,24 @@ import (
 	"time"
 )
 
+func TestMachineTargetStateJSON(t *testing.T) {
+	var machine Machine
+	if err := json.Unmarshal([]byte(`{"id":"machine-id","target_state":"stopped"}`), &machine); err != nil {
+		t.Fatal(err)
+	}
+	if machine.TargetState != MachineStateStopped {
+		t.Fatalf("target state = %q, want %q", machine.TargetState, MachineStateStopped)
+	}
+
+	encoded, err := json.Marshal(Machine{ID: "machine-id"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("target_state")) {
+		t.Fatalf("empty target state should be omitted: %s", encoded)
+	}
+}
+
 func TestIsReleaseCommandMachine(t *testing.T) {
 	type testcase struct {
 		name     string


### PR DESCRIPTION
## What changes

Machine update responses now expose the target state selected by flyd, allowing clients to distinguish a replacement that intentionally remains stopped.

## Scope

- `target_state` is an optional field on the existing Machine response; older servers decode with an empty value and older clients ignore it.
- This PR exposes the server decision but does not change client behavior by itself.

## Testing

- JSON boundary tests verify that clients decode `target_state` and omit it when the server does not return a value.
- The cross-repository Stop/update smoke returned `target_state=stopped` through Flaps for the exact stopped replacement.

Refs superfly/machines-meta#8.
