### PR TITLE
Add Managed Postgres list and delete endpoints

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -69,4 +69,6 @@ const (
 	managedPostgresCreate
 	managedPostgresGet
 	managedPostgresUserCredentialsGet
+	managedPostgresList
+	managedPostgresDelete
 )

--- a/flaps/flaps_error.go
+++ b/flaps/flaps_error.go
@@ -9,6 +9,10 @@ import (
 
 var ErrFlapsNotFound = &FlapsError{ResponseStatusCode: http.StatusNotFound}
 
+// ErrFlapsGone is returned for a recently deleted resource. Managed Postgres
+// clusters eventually transition from Gone to NotFound after deletion.
+var ErrFlapsGone = &FlapsError{ResponseStatusCode: http.StatusGone}
+
 type StatusCode string
 
 const (

--- a/flaps/flaps_error.go
+++ b/flaps/flaps_error.go
@@ -9,8 +9,8 @@ import (
 
 var ErrFlapsNotFound = &FlapsError{ResponseStatusCode: http.StatusNotFound}
 
-// ErrFlapsGone is returned for a recently deleted resource. Managed Postgres
-// clusters eventually transition from Gone to NotFound after deletion.
+// ErrFlapsGone is returned when the API reports a resource as gone (HTTP 410).
+// Managed Postgres returns it for a cluster that has already been deleted.
 var ErrFlapsGone = &FlapsError{ResponseStatusCode: http.StatusGone}
 
 type StatusCode string

--- a/flaps/flaps_managed_postgres.go
+++ b/flaps/flaps_managed_postgres.go
@@ -58,6 +58,19 @@ type ManagedPostgresCluster struct {
 	AttachedApps   []ManagedPostgresAttachedApp `json:"attached_apps"`
 }
 
+// ManagedPostgresClusterSummary is the public projection returned by
+// GET /v1/postgres.
+type ManagedPostgresClusterSummary struct {
+	ID           string                       `json:"id"`
+	Name         string                       `json:"name"`
+	Status       string                       `json:"status"`
+	Region       string                       `json:"region"`
+	Plan         string                       `json:"plan"`
+	CreatedAt    string                       `json:"created_at"`
+	DeletedAt    string                       `json:"deleted_at"`
+	AttachedApps []ManagedPostgresAttachedApp `json:"attached_apps"`
+}
+
 // CreateManagedPostgresClusterRequest is the body for POST /v1/postgres.
 type CreateManagedPostgresClusterRequest struct {
 	OrgSlug        string `json:"org_slug"`
@@ -69,6 +82,13 @@ type CreateManagedPostgresClusterRequest struct {
 	PostGISEnabled bool   `json:"postgis_enabled"`
 }
 
+// ListManagedPostgresClustersRequest contains the query parameters for
+// GET /v1/postgres.
+type ListManagedPostgresClustersRequest struct {
+	OrgSlug        string
+	IncludeDeleted bool
+}
+
 // ManagedPostgresUserCredentials is the response from
 // GET /v1/postgres/:id/users/:username/credentials.
 type ManagedPostgresUserCredentials struct {
@@ -78,6 +98,10 @@ type ManagedPostgresUserCredentials struct {
 
 type managedPostgresClusterEnvelope struct {
 	Data ManagedPostgresCluster `json:"data"`
+}
+
+type managedPostgresClusterListEnvelope struct {
+	Data []ManagedPostgresClusterSummary `json:"data"`
 }
 
 type managedPostgresUserCredentialsEnvelope struct {
@@ -106,6 +130,34 @@ func (f *Client) GetManagedPostgresCluster(ctx context.Context, id string) (Mana
 	}
 
 	return env.Data, nil
+}
+
+func (f *Client) ListManagedPostgresClusters(ctx context.Context, req ListManagedPostgresClustersRequest) ([]ManagedPostgresClusterSummary, error) {
+	ctx = contextWithAction(ctx, managedPostgresList)
+
+	query := url.Values{}
+	query.Set("org_slug", req.OrgSlug)
+	if req.IncludeDeleted {
+		query.Set("include_deleted", "true")
+	}
+
+	var env managedPostgresClusterListEnvelope
+	if err := f._sendRequest(ctx, http.MethodGet, "/postgres?"+query.Encode(), nil, &env, nil); err != nil {
+		return nil, fmt.Errorf("failed to list Managed Postgres clusters: %w", err)
+	}
+
+	return env.Data, nil
+}
+
+func (f *Client) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
+	ctx = contextWithAction(ctx, managedPostgresDelete)
+
+	endpoint := fmt.Sprintf("/postgres/%s", url.PathEscape(id))
+	if err := f._sendRequest(ctx, http.MethodDelete, endpoint, nil, nil, nil); err != nil {
+		return fmt.Errorf("failed to delete Managed Postgres cluster: %w", err)
+	}
+
+	return nil
 }
 
 func (f *Client) GetManagedPostgresUserCredentials(ctx context.Context, id, username string) (ManagedPostgresUserCredentials, error) {

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -1,0 +1,111 @@
+package flaps
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type managedPostgresRoundTripper struct {
+	req        *http.Request
+	statusCode int
+	body       string
+}
+
+func (t *managedPostgresRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.req = req.Clone(req.Context())
+	return &http.Response{
+		StatusCode: t.statusCode,
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestListManagedPostgresClusters(t *testing.T) {
+	transport := &managedPostgresRoundTripper{
+		statusCode: http.StatusOK,
+		body: `{"data":[{"id":"mpg-123","name":"example","status":"ready","region":"iad","plan":"basic",` +
+			`"created_at":"2026-08-24T00:00:00Z","deleted_at":"","attached_apps":[{"name":"example-app"}]}]}`,
+	}
+	client := newTestFlapsClient(t, transport)
+
+	clusters, err := client.ListManagedPostgresClusters(context.Background(), ListManagedPostgresClustersRequest{
+		OrgSlug:        "example-org",
+		IncludeDeleted: true,
+	})
+	if err != nil {
+		t.Fatalf("ListManagedPostgresClusters() error = %v", err)
+	}
+	if transport.req.Method != http.MethodGet {
+		t.Fatalf("request method = %q, want %q", transport.req.Method, http.MethodGet)
+	}
+	if got, want := transport.req.URL.Path, "/v1/postgres"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if got, want := transport.req.URL.Query().Get("org_slug"), "example-org"; got != want {
+		t.Fatalf("org_slug = %q, want %q", got, want)
+	}
+	if got, want := transport.req.URL.Query().Get("include_deleted"), "true"; got != want {
+		t.Fatalf("include_deleted = %q, want %q", got, want)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("cluster count = %d, want 1", len(clusters))
+	}
+	if got, want := clusters[0].ID, "mpg-123"; got != want {
+		t.Fatalf("cluster ID = %q, want %q", got, want)
+	}
+	if got, want := clusters[0].AttachedApps[0].Name, "example-app"; got != want {
+		t.Fatalf("attached app = %q, want %q", got, want)
+	}
+}
+
+func TestListManagedPostgresClustersOmitsIncludeDeletedByDefault(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
+	client := newTestFlapsClient(t, transport)
+
+	_, err := client.ListManagedPostgresClusters(context.Background(), ListManagedPostgresClustersRequest{OrgSlug: "example-org"})
+	if err != nil {
+		t.Fatalf("ListManagedPostgresClusters() error = %v", err)
+	}
+	if transport.req.URL.Query().Has("include_deleted") {
+		t.Fatalf("include_deleted unexpectedly present in query: %q", transport.req.URL.RawQuery)
+	}
+}
+
+func TestListManagedPostgresClustersClassifiesNotFound(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"not found"}`}
+	client := newTestFlapsClient(t, transport)
+
+	_, err := client.ListManagedPostgresClusters(context.Background(), ListManagedPostgresClustersRequest{OrgSlug: "example-org"})
+	if !errors.Is(err, ErrFlapsNotFound) {
+		t.Fatalf("ListManagedPostgresClusters() error = %v, want ErrFlapsNotFound", err)
+	}
+}
+
+func TestDeleteManagedPostgresCluster(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusAccepted}
+	client := newTestFlapsClient(t, transport)
+
+	if err := client.DeleteManagedPostgresCluster(context.Background(), "mpg-123"); err != nil {
+		t.Fatalf("DeleteManagedPostgresCluster() error = %v", err)
+	}
+	if transport.req.Method != http.MethodDelete {
+		t.Fatalf("request method = %q, want %q", transport.req.Method, http.MethodDelete)
+	}
+	if got, want := transport.req.URL.Path, "/v1/postgres/mpg-123"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestDeleteManagedPostgresClusterClassifiesNotFound(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"not found"}`}
+	client := newTestFlapsClient(t, transport)
+
+	err := client.DeleteManagedPostgresCluster(context.Background(), "mpg-123")
+	if !errors.Is(err, ErrFlapsNotFound) {
+		t.Fatalf("DeleteManagedPostgresCluster() error = %v, want ErrFlapsNotFound", err)
+	}
+}

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -28,7 +28,7 @@ func TestListManagedPostgresClusters(t *testing.T) {
 	transport := &managedPostgresRoundTripper{
 		statusCode: http.StatusOK,
 		body: `{"data":[{"id":"mpg-123","name":"example","status":"ready","region":"iad","plan":"basic",` +
-			`"created_at":"2026-08-24T00:00:00Z","deleted_at":"","attached_apps":[{"name":"example-app"}]}]}`,
+			`"created_at":"2026-08-24T00:00:00Z","attached_apps":[{"name":"example-app"}]}]}`,
 	}
 	client := newTestFlapsClient(t, transport)
 
@@ -107,5 +107,15 @@ func TestDeleteManagedPostgresClusterClassifiesNotFound(t *testing.T) {
 	err := client.DeleteManagedPostgresCluster(context.Background(), "mpg-123")
 	if !errors.Is(err, ErrFlapsNotFound) {
 		t.Fatalf("DeleteManagedPostgresCluster() error = %v, want ErrFlapsNotFound", err)
+	}
+}
+
+func TestDeleteManagedPostgresClusterClassifiesGone(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusGone, body: `{"error":"gone"}`}
+	client := newTestFlapsClient(t, transport)
+
+	err := client.DeleteManagedPostgresCluster(context.Background(), "mpg-123")
+	if !errors.Is(err, ErrFlapsGone) {
+		t.Fatalf("DeleteManagedPostgresCluster() error = %v, want ErrFlapsGone", err)
 	}
 }

--- a/flaps/flapsaction_string.go
+++ b/flaps/flapsaction_string.go
@@ -71,11 +71,13 @@ func _() {
 	_ = x[managedPostgresCreate-60]
 	_ = x[managedPostgresGet-61]
 	_ = x[managedPostgresUserCredentialsGet-62]
+	_ = x[managedPostgresList-63]
+	_ = x[managedPostgresDelete-64]
 }
 
-const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGet"
+const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDelete"
 
-var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908}
+var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948}
 
 func (i flapsAction) String() string {
 	idx := int(i) - 0


### PR DESCRIPTION
Adds Managed Postgres list/delete support to the flaps client, including request and error-classification coverage.

Follow-up: migrate flyctl's MPGv2 lifecycle paths after this lands.

Test: `go test ./... -count=1`
