### PR TITLE
tokens: cap discharge polling and make its timeout configurable

### DIFF
--- a/tokens/discharge_test.go
+++ b/tokens/discharge_test.go
@@ -1,0 +1,155 @@
+package tokens
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/superfly/macaroon"
+	"github.com/superfly/macaroon/flyio"
+	"github.com/superfly/macaroon/tp"
+)
+
+// TestDischargePollingBackoff guards the cap on the discharge polling
+// interval. The tp client's own backoff doubles without bound, so it stops
+// asking the third party long before it runs out of time and a discharge that
+// becomes ready in the meantime isn't collected until the next poll, if there
+// is one. Interactive discharges wait on a person finishing a login, so the
+// interval has to stay short enough to notice when they do.
+func TestDischargePollingBackoff(t *testing.T) {
+	var (
+		bo      time.Duration
+		elapsed time.Duration
+	)
+
+	for i := 0; i < 200; i++ {
+		bo = dischargePollingBackoff(bo)
+
+		if bo > maxDischargePollBackoff {
+			t.Fatalf("poll %d: backoff %s exceeds cap %s", i, bo, maxDischargePollBackoff)
+		}
+		if bo <= 0 {
+			t.Fatalf("poll %d: non-positive backoff %s", i, bo)
+		}
+
+		elapsed += bo
+	}
+
+	// with the cap in place, the whole default timeout is covered by polls
+	// rather than by one long sleep.
+	if elapsed < DefaultDischargeTimeout {
+		t.Fatalf("200 polls only cover %s, less than the %s default timeout", elapsed, DefaultDischargeTimeout)
+	}
+}
+
+// TestUpdateDischarge exercises Update against a real third party that answers
+// with a poll URL and only discharges later, which is what an interactive
+// login looks like from the client's side.
+func TestUpdateDischarge(t *testing.T) {
+	t.Run("collects a discharge that arrives between polls", func(t *testing.T) {
+		// the discharge lands after the fourth poll of the capped schedule
+		// (0, 100ms, 300ms, 700ms, ...) and well before the deadline. An
+		// unbounded backoff would already be sleeping past the deadline by
+		// then and would report a timeout for a discharge that was ready.
+		hdr := newTestThirdParty(t, 1200*time.Millisecond)
+
+		toks := Parse(hdr)
+
+		updated, err := toks.Update(context.Background(), WithDischargeTimeout(2500*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if !updated {
+			t.Fatal("expected tokens to be updated with a discharge")
+		}
+		if n := len(Parse(toks.All()).macaroons); n != 2 {
+			t.Fatalf("expected permission and discharge tokens, got %d macaroons", n)
+		}
+	})
+
+	t.Run("gives up after the configured timeout", func(t *testing.T) {
+		// never discharged: Update can only stop when its own deadline passes.
+		hdr := newTestThirdParty(t, 0)
+
+		toks := Parse(hdr)
+
+		start := time.Now()
+		_, err := toks.Update(context.Background(), WithDischargeTimeout(500*time.Millisecond))
+		took := time.Since(start)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected a deadline error, got %v", err)
+		}
+		if took > 5*time.Second {
+			t.Fatalf("Update took %s: the timeout isn't coming from WithDischargeTimeout", took)
+		}
+	})
+}
+
+// newTestThirdParty stands up a third party that responds to discharge
+// requests with a poll URL, and discharges after the given delay if it is
+// non-zero. It returns an authorization header holding a permission token with
+// a third party caveat for that server.
+func newTestThirdParty(tb testing.TB, dischargeAfter time.Duration) string {
+	tb.Helper()
+
+	var (
+		thirdParty *tp.TP
+		discharged = make(chan string, 1)
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch path := r.URL.EscapedPath(); {
+		case path == tp.InitPath:
+			thirdParty.InitRequestMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				discharged <- thirdParty.RespondPoll(w, r)
+			})).ServeHTTP(w, r)
+		case strings.HasPrefix(path, tp.PollPathPrefix):
+			thirdParty.HandlePollRequest(w, r)
+		default:
+			tb.Errorf("unexpected request to %s", path)
+		}
+	}))
+	tb.Cleanup(server.Close)
+
+	store, err := tp.NewMemoryStore(tp.PrefixMunger("/user/"), 100)
+	if err != nil {
+		tb.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	thirdParty = &tp.TP{
+		Location: server.URL,
+		Key:      macaroon.NewEncryptionKey(),
+		Store:    store,
+	}
+
+	if dischargeAfter > 0 {
+		go func() {
+			pollSecret := <-discharged
+			time.Sleep(dischargeAfter)
+
+			if err := thirdParty.DischargePoll(context.Background(), pollSecret); err != nil {
+				tb.Errorf("DischargePoll: %v", err)
+			}
+		}()
+	}
+
+	m, err := macaroon.New([]byte("kid"), flyio.LocationPermission, macaroon.NewSigningKey())
+	if err != nil {
+		tb.Fatalf("macaroon.New: %v", err)
+	}
+	if err := m.Add3P(thirdParty.Key, thirdParty.Location); err != nil {
+		tb.Fatalf("Add3P: %v", err)
+	}
+
+	tok, err := m.Encode()
+	if err != nil {
+		tb.Fatalf("Encode: %v", err)
+	}
+
+	return macaroon.ToAuthorizationHeader(tok)
+}

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -181,7 +181,11 @@ func (t *Tokens) Empty() bool {
 // Update prunes any invalid/expired macaroons and fetches needed third party
 // discharges
 func (t *Tokens) Update(ctx context.Context, opts ...UpdateOption) (bool, error) {
-	options := &updateOptions{debugger: noopDebugger{}, advancePrune: 1 * time.Minute}
+	options := &updateOptions{
+		debugger:         noopDebugger{},
+		advancePrune:     1 * time.Minute,
+		dischargeTimeout: DefaultDischargeTimeout,
+	}
 	for _, o := range opts {
 		o(options)
 	}
@@ -322,6 +326,38 @@ func (t *Tokens) pruneBadMacaroons(options *updateOptions) bool {
 	return updated
 }
 
+const (
+	// DefaultDischargeTimeout is how long Update spends fetching third party
+	// discharges before giving up. Discharges that need the user to complete a
+	// login in their browser are bounded by how fast a person can work through
+	// an identity provider, not by how fast a server responds, so this is sized
+	// for a human round trip rather than an HTTP one. Callers that know they
+	// are non-interactive can lower it with WithDischargeTimeout.
+	DefaultDischargeTimeout = 90 * time.Second
+
+	// maxDischargePollBackoff caps how long the discharge client waits between
+	// polls. The doubling backoff it uses by default is unbounded, so the
+	// interval keeps growing while the user is still in their browser and the
+	// discharge sits ready for most of the gap between two polls. Polling once
+	// a second for a minute or two costs the third party very little and keeps
+	// the CLI's response to a finished login immediate.
+	maxDischargePollBackoff = 1 * time.Second
+)
+
+// dischargePollingBackoff is the backoff schedule used when polling a third
+// party for a discharge: doubling, but capped so it never outgrows the
+// interactive flow it is waiting on.
+func dischargePollingBackoff(lastBO time.Duration) time.Duration {
+	switch {
+	case lastBO <= 0:
+		return 100 * time.Millisecond
+	case 2*lastBO > maxDischargePollBackoff:
+		return maxDischargePollBackoff
+	default:
+		return 2 * lastBO
+	}
+}
+
 // dischargeThirdPartyCaveats attempts to fetch any necessary discharge tokens
 // for 3rd party caveats found within macaroon tokens.
 //
@@ -349,8 +385,12 @@ func (t *Tokens) dischargeThirdPartyCaveats(ctx context.Context, options *update
 		},
 	}
 
-	copts := options.clientOptions
-	copts = append(copts, tp.WithHTTP(h))
+	// caller-supplied options come last so they can override these defaults.
+	copts := []tp.ClientOption{
+		tp.WithHTTP(h),
+		tp.WithPollingBackoff(dischargePollingBackoff),
+	}
+	copts = append(copts, options.clientOptions...)
 	if oauths != "" {
 		copts = append(copts,
 			tp.WithBearerAuthentication("auth.fly.io", oauths),
@@ -366,7 +406,7 @@ func (t *Tokens) dischargeThirdPartyCaveats(ctx context.Context, options *update
 		return false, nil
 	}
 
-	toCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	toCtx, cancel := context.WithTimeout(ctx, options.dischargeTimeout)
 	defer cancel()
 
 	options.debugger.Debug("Attempting to upgrade authentication token")
@@ -388,9 +428,10 @@ func (t *Tokens) dischargeThirdPartyCaveats(ctx context.Context, options *update
 type UpdateOption func(*updateOptions)
 
 type updateOptions struct {
-	clientOptions []tp.ClientOption
-	debugger      Debugger
-	advancePrune  time.Duration
+	clientOptions    []tp.ClientOption
+	debugger         Debugger
+	advancePrune     time.Duration
+	dischargeTimeout time.Duration
 }
 
 func WithUserURLCallback(cb func(ctx context.Context, url string) error) UpdateOption {
@@ -416,6 +457,14 @@ func (noopDebugger) Debug(...any) {}
 func WithAdvancePrune(advancePrune time.Duration) UpdateOption {
 	return func(o *updateOptions) {
 		o.advancePrune = advancePrune
+	}
+}
+
+// WithDischargeTimeout overrides how long Update will spend fetching third
+// party discharges before giving up. See DefaultDischargeTimeout.
+func WithDischargeTimeout(timeout time.Duration) UpdateOption {
+	return func(o *updateOptions) {
+		o.dischargeTimeout = timeout
 	}
 }
 


### PR DESCRIPTION
Fetching third party discharges ran under a hardcoded 30 second context while
the `tp` client polled on its default unbounded doubling backoff. Polls land at
t=0,1,3,7,15 and the next one is scheduled for t=31, so the client stops asking
for the second half of the time it was given; and 30 seconds was never much of
a budget for a discharge that waits on a person completing a login in their
browser. This caps the polling interval at a second and routes the timeout
through an `UpdateOption`, `WithDischargeTimeout`, with the default raised to
90 seconds.

## Context

A discharge that needs user interaction only exists once the user finishes
authenticating at the third party. The client's entire job in between is to
notice when that happens, and an unbounded backoff makes it worst at exactly
the moment it matters most: the longer the person takes, the longer the
discharge sits ready and uncollected. Past the point where the interval
outgrows the remaining budget it is never collected at all, and `Update`
returns `context deadline exceeded` for a login that succeeded in good time.

The new default deserves an explicit justification. An interactive round trip
through an identity provider is realistically 10-30 seconds of human time
(page loads, an account chooser, a password manager, an MFA prompt, a redirect
chain), and the tail is much longer than the median. 30 seconds was sized like
an HTTP timeout rather than a human one. 90 covers the tail with room to spare
while staying bounded, and callers that know they are non-interactive can now
lower it instead of living with a constant. Anyone tuning it further should
know that flyctl's `refreshDischargeTokens` calls `Tokens.Update` twice, each
building its own context, so the user-visible worst case is about twice
whatever this value is.

## Details

`dischargePollingBackoff` doubles from 100ms up to a 1 second cap and is passed
via `tp.WithPollingBackoff`. Polling a third party once a second while a person
is mid-login costs it very little, and it keeps the response to a finished
login immediate. Caller-supplied client options are now appended after these
defaults so they can still override them.

This is deliberately standalone. It uses only `tp.WithPollingBackoff`, public
since macaroon v0.3.0, so it needs no macaroon release to be effective; the
tests here pass against v0.3.0 as well as against macaroon `main`.
superfly/macaroon#46 makes the poll loop deadline-aware in general, which is
the better fix and helps every consumer of the library, but the two are
independent and either one alone closes the window this package cares about.
