### PR TITLE
Bump macaroon to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.4.0
 	github.com/superfly/client-signals/go v0.4.4
 	github.com/superfly/graphql v0.2.6
-	github.com/superfly/macaroon v0.3.0
+	github.com/superfly/macaroon v0.3.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/crypto v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVu
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
-github.com/superfly/macaroon v0.3.0 h1:tdRq5VqBCNJIlvYByZZ3bGDOKX/v0llQM/Ljd27DbU8=
-github.com/superfly/macaroon v0.3.0/go.mod h1:ZAmlRD/Hmp/ddTxE8IonZ7NdTny2DcOffRvZhapQwJw=
+github.com/superfly/macaroon v0.3.1 h1:02JF233876dGI53tm/cb72yUkAYKzwQjL1npMYLqE10=
+github.com/superfly/macaroon v0.3.1/go.mod h1:ZAmlRD/Hmp/ddTxE8IonZ7NdTny2DcOffRvZhapQwJw=
 github.com/vektah/gqlparser/v2 v2.5.32 h1:k9QPJd4sEDTL+qB4ncPLflqTJ3MmjB9SrVzJrawpFSc=
 github.com/vektah/gqlparser/v2 v2.5.32/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=


### PR DESCRIPTION
Picks up macaroon v0.3.1, whose `tp` client stops polling past its own deadline.

## Context

superfly/macaroon#46 makes the third party poll loop clamp its backoff against the caller's context, so a final poll always lands before the deadline instead of the client sleeping through the rest of its budget. #286 already bounded that from this side by capping the polling interval, so this is not a fix fly-go needs; it is the general version of it, and taking the release means consumers get the correct behaviour for any discharge client they build themselves.