### PR TITLE
Add Managed Postgres database endpoints

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -71,4 +71,6 @@ const (
 	managedPostgresUserCredentialsGet
 	managedPostgresList
 	managedPostgresDelete
+	managedPostgresDatabaseList
+	managedPostgresDatabaseCreate
 )

--- a/flaps/flaps_managed_postgres.go
+++ b/flaps/flaps_managed_postgres.go
@@ -96,6 +96,18 @@ type ManagedPostgresUserCredentials struct {
 	Password string `json:"password"`
 }
 
+// ManagedPostgresDatabase is the public projection of a database within a
+// Managed Postgres cluster returned by list/create.
+type ManagedPostgresDatabase struct {
+	Name string `json:"name"`
+}
+
+// CreateManagedPostgresDatabaseRequest is the body for
+// POST /v1/postgres/:id/databases.
+type CreateManagedPostgresDatabaseRequest struct {
+	Name string `json:"name"`
+}
+
 type managedPostgresClusterEnvelope struct {
 	Data ManagedPostgresCluster `json:"data"`
 }
@@ -106,6 +118,14 @@ type managedPostgresClusterListEnvelope struct {
 
 type managedPostgresUserCredentialsEnvelope struct {
 	Data ManagedPostgresUserCredentials `json:"data"`
+}
+
+type managedPostgresDatabaseEnvelope struct {
+	Data ManagedPostgresDatabase `json:"data"`
+}
+
+type managedPostgresDatabaseListEnvelope struct {
+	Data []ManagedPostgresDatabase `json:"data"`
 }
 
 func (f *Client) CreateManagedPostgresCluster(ctx context.Context, req CreateManagedPostgresClusterRequest) (ManagedPostgresCluster, error) {
@@ -168,6 +188,32 @@ func (f *Client) GetManagedPostgresUserCredentials(ctx context.Context, id, user
 	var env managedPostgresUserCredentialsEnvelope
 	if err := f._sendRequest(ctx, http.MethodGet, endpoint, nil, &env, nil); err != nil {
 		return ManagedPostgresUserCredentials{}, fmt.Errorf("failed to get Managed Postgres user credentials: %w", err)
+	}
+
+	return env.Data, nil
+}
+
+func (f *Client) ListManagedPostgresDatabases(ctx context.Context, id string) ([]ManagedPostgresDatabase, error) {
+	ctx = contextWithAction(ctx, managedPostgresDatabaseList)
+
+	endpoint := fmt.Sprintf("/postgres/%s/databases", url.PathEscape(id))
+
+	var env managedPostgresDatabaseListEnvelope
+	if err := f._sendRequest(ctx, http.MethodGet, endpoint, nil, &env, nil); err != nil {
+		return nil, fmt.Errorf("failed to list Managed Postgres databases: %w", err)
+	}
+
+	return env.Data, nil
+}
+
+func (f *Client) CreateManagedPostgresDatabase(ctx context.Context, id string, req CreateManagedPostgresDatabaseRequest) (ManagedPostgresDatabase, error) {
+	ctx = contextWithAction(ctx, managedPostgresDatabaseCreate)
+
+	endpoint := fmt.Sprintf("/postgres/%s/databases", url.PathEscape(id))
+
+	var env managedPostgresDatabaseEnvelope
+	if err := f._sendRequest(ctx, http.MethodPost, endpoint, req, &env, nil); err != nil {
+		return ManagedPostgresDatabase{}, fmt.Errorf("failed to create Managed Postgres database: %w", err)
 	}
 
 	return env.Data, nil

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -2,6 +2,7 @@ package flaps
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -117,5 +118,114 @@ func TestDeleteManagedPostgresClusterClassifiesGone(t *testing.T) {
 	err := client.DeleteManagedPostgresCluster(context.Background(), "mpg-123")
 	if !errors.Is(err, ErrFlapsGone) {
 		t.Fatalf("DeleteManagedPostgresCluster() error = %v, want ErrFlapsGone", err)
+	}
+}
+
+func TestListManagedPostgresDatabases(t *testing.T) {
+	transport := &managedPostgresRoundTripper{
+		statusCode: http.StatusOK,
+		body:       `{"data":[{"name":"app"},{"name":"reports"}]}`,
+	}
+	client := newTestFlapsClient(t, transport)
+
+	databases, err := client.ListManagedPostgresDatabases(context.Background(), "mpg-123")
+	if err != nil {
+		t.Fatalf("ListManagedPostgresDatabases() error = %v", err)
+	}
+	if transport.req.Method != http.MethodGet {
+		t.Fatalf("request method = %q, want %q", transport.req.Method, http.MethodGet)
+	}
+	if got, want := transport.req.URL.Path, "/v1/postgres/mpg-123/databases"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if len(databases) != 2 {
+		t.Fatalf("database count = %d, want 2", len(databases))
+	}
+	if got, want := databases[0].Name, "app"; got != want {
+		t.Fatalf("databases[0].Name = %q, want %q", got, want)
+	}
+	if got, want := databases[1].Name, "reports"; got != want {
+		t.Fatalf("databases[1].Name = %q, want %q", got, want)
+	}
+}
+
+func TestListManagedPostgresDatabasesEscapesClusterID(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
+	client := newTestFlapsClient(t, transport)
+
+	if _, err := client.ListManagedPostgresDatabases(context.Background(), "my?cluster"); err != nil {
+		t.Fatalf("ListManagedPostgresDatabases() error = %v", err)
+	}
+	if got, want := transport.req.URL.EscapedPath(), "/v1/postgres/my%3Fcluster/databases"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestListManagedPostgresDatabasesClassifiesNotFound(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"Cluster not found"}`}
+	client := newTestFlapsClient(t, transport)
+
+	_, err := client.ListManagedPostgresDatabases(context.Background(), "mpg-123")
+	if !errors.Is(err, ErrFlapsNotFound) {
+		t.Fatalf("ListManagedPostgresDatabases() error = %v, want ErrFlapsNotFound", err)
+	}
+}
+
+func TestCreateManagedPostgresDatabase(t *testing.T) {
+	transport := &managedPostgresRoundTripper{
+		statusCode: http.StatusCreated,
+		body:       `{"data":{"name":"reports"}}`,
+	}
+	client := newTestFlapsClient(t, transport)
+
+	database, err := client.CreateManagedPostgresDatabase(context.Background(), "mpg-123", CreateManagedPostgresDatabaseRequest{Name: "reports"})
+	if err != nil {
+		t.Fatalf("CreateManagedPostgresDatabase() error = %v", err)
+	}
+	if transport.req.Method != http.MethodPost {
+		t.Fatalf("request method = %q, want %q", transport.req.Method, http.MethodPost)
+	}
+	if got, want := transport.req.URL.Path, "/v1/postgres/mpg-123/databases"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+
+	body, err := io.ReadAll(transport.req.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var sent struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decode request body %q: %v", string(body), err)
+	}
+	if got, want := sent.Name, "reports"; got != want {
+		t.Fatalf("sent name = %q, want %q", got, want)
+	}
+
+	if got, want := database.Name, "reports"; got != want {
+		t.Fatalf("database.Name = %q, want %q", got, want)
+	}
+}
+
+func TestCreateManagedPostgresDatabaseEscapesClusterID(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusCreated, body: `{"data":{"name":"reports"}}`}
+	client := newTestFlapsClient(t, transport)
+
+	if _, err := client.CreateManagedPostgresDatabase(context.Background(), "my?cluster", CreateManagedPostgresDatabaseRequest{Name: "reports"}); err != nil {
+		t.Fatalf("CreateManagedPostgresDatabase() error = %v", err)
+	}
+	if got, want := transport.req.URL.EscapedPath(), "/v1/postgres/my%3Fcluster/databases"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestCreateManagedPostgresDatabaseClassifiesNotFound(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"Cluster not found"}`}
+	client := newTestFlapsClient(t, transport)
+
+	_, err := client.CreateManagedPostgresDatabase(context.Background(), "mpg-123", CreateManagedPostgresDatabaseRequest{Name: "reports"})
+	if !errors.Is(err, ErrFlapsNotFound) {
+		t.Fatalf("CreateManagedPostgresDatabase() error = %v, want ErrFlapsNotFound", err)
 	}
 }

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -149,7 +149,7 @@ func TestListManagedPostgresDatabases(t *testing.T) {
 	}
 }
 
-func TestListManagedPostgresDatabasesEscapesClusterID(t *testing.T) {
+func TestListManagedPostgresDatabasesEscapesQuestionMarkInClusterID(t *testing.T) {
 	transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
 	client := newTestFlapsClient(t, transport)
 
@@ -208,7 +208,7 @@ func TestCreateManagedPostgresDatabase(t *testing.T) {
 	}
 }
 
-func TestCreateManagedPostgresDatabaseEscapesClusterID(t *testing.T) {
+func TestCreateManagedPostgresDatabaseEscapesQuestionMarkInClusterID(t *testing.T) {
 	transport := &managedPostgresRoundTripper{statusCode: http.StatusCreated, body: `{"data":{"name":"reports"}}`}
 	client := newTestFlapsClient(t, transport)
 

--- a/flaps/flapsaction_string.go
+++ b/flaps/flapsaction_string.go
@@ -73,11 +73,13 @@ func _() {
 	_ = x[managedPostgresUserCredentialsGet-62]
 	_ = x[managedPostgresList-63]
 	_ = x[managedPostgresDelete-64]
+	_ = x[managedPostgresDatabaseList-65]
+	_ = x[managedPostgresDatabaseCreate-66]
 }
 
-const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDelete"
+const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDeletemanagedPostgresDatabaseListmanagedPostgresDatabaseCreate"
 
-var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948}
+var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948, 975, 1004}
 
 func (i flapsAction) String() string {
 	idx := int(i) - 0


### PR DESCRIPTION
Adds database list and create support to the Flaps client for the existing Managed Postgres endpoints:

- `GET /v1/postgres/{id}/databases`
- `POST /v1/postgres/{id}/databases`

Tests cover request shape, response decoding, and not-found classification.

Test: `go test ./... -count=1`
