### PR TITLE
Add NetworkCIDR to App

### DIFF
--- a/flaps/flaps_apps.go
+++ b/flaps/flaps_apps.go
@@ -34,6 +34,7 @@ type App struct {
 	Name              string `json:"name"`
 	InternalNumericID int32  `json:"internal_numeric_id"`
 	Network           string `json:"network"`
+	NetworkCIDR       string `json:"network_cidr"`
 	Status            string `json:"status"`
 
 	MachineCount int64 `json:"machine_count"`


### PR DESCRIPTION
The flaps API already returns `network_cidr` in its app responses
on create, get and list, but `flaps.App` had no field for it, so the
value was silently dropped on decode.

Here we add `NetworkCIDR` to `App` so it flows out of `CreateApp`,
`GetApp` and `ListApps` with no signature changes.

Signed-off-by: Juliana Oliveira <juliana@fly.io>
