### PR TITLE
Add Managed Postgres backup methods

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -73,4 +73,6 @@ const (
 	managedPostgresDelete
 	managedPostgresDatabaseList
 	managedPostgresDatabaseCreate
+	managedPostgresBackupList
+	managedPostgresBackupCreate
 )

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -236,7 +236,11 @@ func (f *Client) urlFromBaseUrl(pathAndQueryString string) (*url.URL, error) {
 		return nil, fmt.Errorf("failed parsing flaps path '%s' with error: %w", pathAndQueryString, err)
 	}
 
-	return newUrl.ResolveReference(&url.URL{Path: newPath.Path, RawQuery: newPath.RawQuery}), nil
+	return newUrl.ResolveReference(&url.URL{
+		Path:     newPath.Path,
+		RawPath:  newPath.RawPath,
+		RawQuery: newPath.RawQuery,
+	}), nil
 }
 
 func (f *Client) NewRequest(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error) {

--- a/flaps/flaps_managed_postgres.go
+++ b/flaps/flaps_managed_postgres.go
@@ -108,6 +108,23 @@ type CreateManagedPostgresDatabaseRequest struct {
 	Name string `json:"name"`
 }
 
+// ManagedPostgresBackup is the public projection of a backup belonging to a
+// Managed Postgres cluster.
+type ManagedPostgresBackup struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"`
+	Type       string `json:"type"`
+	SizeBytes  int64  `json:"size_bytes"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at"`
+}
+
+// CreateManagedPostgresBackupRequest is the body for
+// POST /v1/postgres/:id/backups.
+type CreateManagedPostgresBackupRequest struct {
+	Type string `json:"type"`
+}
+
 type managedPostgresClusterEnvelope struct {
 	Data ManagedPostgresCluster `json:"data"`
 }
@@ -126,6 +143,10 @@ type managedPostgresDatabaseEnvelope struct {
 
 type managedPostgresDatabaseListEnvelope struct {
 	Data []ManagedPostgresDatabase `json:"data"`
+}
+
+type managedPostgresBackupListEnvelope struct {
+	Data []ManagedPostgresBackup `json:"data"`
 }
 
 func (f *Client) CreateManagedPostgresCluster(ctx context.Context, req CreateManagedPostgresClusterRequest) (ManagedPostgresCluster, error) {
@@ -217,4 +238,28 @@ func (f *Client) CreateManagedPostgresDatabase(ctx context.Context, id string, r
 	}
 
 	return env.Data, nil
+}
+
+func (f *Client) ListManagedPostgresBackups(ctx context.Context, id string) ([]ManagedPostgresBackup, error) {
+	ctx = contextWithAction(ctx, managedPostgresBackupList)
+
+	endpoint := fmt.Sprintf("/postgres/%s/backups", url.PathEscape(id))
+
+	var env managedPostgresBackupListEnvelope
+	if err := f._sendRequest(ctx, http.MethodGet, endpoint, nil, &env, nil); err != nil {
+		return nil, fmt.Errorf("failed to list Managed Postgres backups: %w", err)
+	}
+
+	return env.Data, nil
+}
+
+func (f *Client) CreateManagedPostgresBackup(ctx context.Context, id string, req CreateManagedPostgresBackupRequest) error {
+	ctx = contextWithAction(ctx, managedPostgresBackupCreate)
+
+	endpoint := fmt.Sprintf("/postgres/%s/backups", url.PathEscape(id))
+	if err := f._sendRequest(ctx, http.MethodPost, endpoint, req, nil, nil); err != nil {
+		return fmt.Errorf("failed to create Managed Postgres backup: %w", err)
+	}
+
+	return nil
 }

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -229,3 +229,179 @@ func TestCreateManagedPostgresDatabaseClassifiesNotFound(t *testing.T) {
 		t.Fatalf("CreateManagedPostgresDatabase() error = %v, want ErrFlapsNotFound", err)
 	}
 }
+
+func TestListManagedPostgresBackups(t *testing.T) {
+	transport := &managedPostgresRoundTripper{
+		statusCode: http.StatusOK,
+		body: `{"data":[{"id":"backup-1","status":"completed","type":"full","size_bytes":1234,` +
+			`"started_at":"2026-08-26T12:00:00Z","finished_at":"2026-08-26T12:05:00Z"}]}`,
+	}
+	client := newTestFlapsClient(t, transport)
+
+	backups, err := client.ListManagedPostgresBackups(context.Background(), "mpg-123")
+	if err != nil {
+		t.Fatalf("ListManagedPostgresBackups() error = %v", err)
+	}
+	if transport.req.Method != http.MethodGet {
+		t.Fatalf("request method = %q, want %q", transport.req.Method, http.MethodGet)
+	}
+	if got, want := transport.req.URL.Path, "/v1/postgres/mpg-123/backups"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("backup count = %d, want 1", len(backups))
+	}
+	backup := backups[0]
+	if got, want := backup.ID, "backup-1"; got != want {
+		t.Fatalf("backup ID = %q, want %q", got, want)
+	}
+	if got, want := backup.SizeBytes, int64(1234); got != want {
+		t.Fatalf("backup size = %d, want %d", got, want)
+	}
+	if got, want := backup.StartedAt, "2026-08-26T12:00:00Z"; got != want {
+		t.Fatalf("backup start = %q, want %q", got, want)
+	}
+}
+
+func TestListManagedPostgresBackupsEscapesClusterID(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
+	client := newTestFlapsClient(t, transport)
+
+	if _, err := client.ListManagedPostgresBackups(context.Background(), "my?cluster"); err != nil {
+		t.Fatalf("ListManagedPostgresBackups() error = %v", err)
+	}
+	if got, want := transport.req.URL.EscapedPath(), "/v1/postgres/my%3Fcluster/backups"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestListManagedPostgresBackupsPreservesEscapedPath(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		clusterID   string
+		expectedURI string
+	}{
+		{name: "slash", clusterID: "a/b", expectedURI: "/v1/postgres/a%2Fb/backups"},
+		{name: "slash and dot segment", clusterID: "a/../b", expectedURI: "/v1/postgres/a%2F..%2Fb/backups"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
+			client := newTestFlapsClient(t, transport)
+			if _, err := client.ListManagedPostgresBackups(context.Background(), test.clusterID); err != nil {
+				t.Fatalf("ListManagedPostgresBackups() error = %v", err)
+			}
+			if got := transport.req.URL.RequestURI(); got != test.expectedURI {
+				t.Fatalf("request URI = %q, want %q", got, test.expectedURI)
+			}
+		})
+	}
+}
+
+func TestURLFromBaseURLPreservesRawPathAndQuery(t *testing.T) {
+	client := newTestFlapsClient(t, &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{}`})
+
+	got, err := client.urlFromBaseUrl("/v1/postgres/a%2Fb/backups?include_deleted=true")
+	if err != nil {
+		t.Fatalf("urlFromBaseUrl() error = %v", err)
+	}
+	if want := "/v1/postgres/a%2Fb/backups?include_deleted=true"; got.RequestURI() != want {
+		t.Fatalf("request URI = %q, want %q", got.RequestURI(), want)
+	}
+}
+
+func TestListManagedPostgresBackupsClassifiesNotFound(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"Cluster not found"}`}
+	client := newTestFlapsClient(t, transport)
+
+	_, err := client.ListManagedPostgresBackups(context.Background(), "mpg-123")
+	if !errors.Is(err, ErrFlapsNotFound) {
+		t.Fatalf("ListManagedPostgresBackups() error = %v, want ErrFlapsNotFound", err)
+	}
+}
+
+func TestCreateManagedPostgresBackup(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusAccepted}
+	client := newTestFlapsClient(t, transport)
+
+	if err := client.CreateManagedPostgresBackup(context.Background(), "mpg-123", CreateManagedPostgresBackupRequest{Type: "incr"}); err != nil {
+		t.Fatalf("CreateManagedPostgresBackup() error = %v", err)
+	}
+	if transport.req.Method != http.MethodPost {
+		t.Fatalf("request method = %q, want %q", transport.req.Method, http.MethodPost)
+	}
+	if got, want := transport.req.URL.Path, "/v1/postgres/mpg-123/backups"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	body, err := io.ReadAll(transport.req.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var sent CreateManagedPostgresBackupRequest
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decode request body %q: %v", string(body), err)
+	}
+	if got, want := sent.Type, "incr"; got != want {
+		t.Fatalf("sent type = %q, want %q", got, want)
+	}
+}
+
+func TestCreateManagedPostgresBackupEscapesClusterID(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusAccepted}
+	client := newTestFlapsClient(t, transport)
+
+	if err := client.CreateManagedPostgresBackup(context.Background(), "my?cluster", CreateManagedPostgresBackupRequest{Type: "full"}); err != nil {
+		t.Fatalf("CreateManagedPostgresBackup() error = %v", err)
+	}
+	if got, want := transport.req.URL.EscapedPath(), "/v1/postgres/my%3Fcluster/backups"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestCreateManagedPostgresBackupPreservesEscapedPath(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		clusterID   string
+		expectedURI string
+	}{
+		{name: "slash", clusterID: "a/b", expectedURI: "/v1/postgres/a%2Fb/backups"},
+		{name: "slash and dot segment", clusterID: "a/../b", expectedURI: "/v1/postgres/a%2F..%2Fb/backups"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &managedPostgresRoundTripper{statusCode: http.StatusAccepted}
+			client := newTestFlapsClient(t, transport)
+			if err := client.CreateManagedPostgresBackup(context.Background(), test.clusterID, CreateManagedPostgresBackupRequest{Type: "full"}); err != nil {
+				t.Fatalf("CreateManagedPostgresBackup() error = %v", err)
+			}
+			if got := transport.req.URL.RequestURI(); got != test.expectedURI {
+				t.Fatalf("request URI = %q, want %q", got, test.expectedURI)
+			}
+		})
+	}
+}
+
+func TestCreateManagedPostgresBackupClassifiesConflict(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusConflict, body: `{"error":"backup already in progress"}`}
+	client := newTestFlapsClient(t, transport)
+
+	err := client.CreateManagedPostgresBackup(context.Background(), "mpg-123", CreateManagedPostgresBackupRequest{Type: "full"})
+	var flapsErr *FlapsError
+	if !errors.As(err, &flapsErr) {
+		t.Fatalf("CreateManagedPostgresBackup() error = %v, want FlapsError", err)
+	}
+	if got, want := flapsErr.ResponseStatusCode, http.StatusConflict; got != want {
+		t.Fatalf("response status = %d, want %d", got, want)
+	}
+	if got, want := flapsErr.Error(), "backup already in progress"; got != want {
+		t.Fatalf("error message = %q, want %q", got, want)
+	}
+}
+
+func TestCreateManagedPostgresBackupClassifiesNotFound(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"Cluster not found"}`}
+	client := newTestFlapsClient(t, transport)
+
+	err := client.CreateManagedPostgresBackup(context.Background(), "mpg-123", CreateManagedPostgresBackupRequest{Type: "full"})
+	if !errors.Is(err, ErrFlapsNotFound) {
+		t.Fatalf("CreateManagedPostgresBackup() error = %v, want ErrFlapsNotFound", err)
+	}
+}

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -263,40 +263,6 @@ func TestListManagedPostgresBackups(t *testing.T) {
 	}
 }
 
-func TestListManagedPostgresBackupsEscapesClusterID(t *testing.T) {
-	transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
-	client := newTestFlapsClient(t, transport)
-
-	if _, err := client.ListManagedPostgresBackups(context.Background(), "my?cluster"); err != nil {
-		t.Fatalf("ListManagedPostgresBackups() error = %v", err)
-	}
-	if got, want := transport.req.URL.EscapedPath(), "/v1/postgres/my%3Fcluster/backups"; got != want {
-		t.Fatalf("request path = %q, want %q", got, want)
-	}
-}
-
-func TestListManagedPostgresBackupsPreservesEscapedPath(t *testing.T) {
-	for _, test := range []struct {
-		name        string
-		clusterID   string
-		expectedURI string
-	}{
-		{name: "slash", clusterID: "a/b", expectedURI: "/v1/postgres/a%2Fb/backups"},
-		{name: "slash and dot segment", clusterID: "a/../b", expectedURI: "/v1/postgres/a%2F..%2Fb/backups"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			transport := &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{"data":[]}`}
-			client := newTestFlapsClient(t, transport)
-			if _, err := client.ListManagedPostgresBackups(context.Background(), test.clusterID); err != nil {
-				t.Fatalf("ListManagedPostgresBackups() error = %v", err)
-			}
-			if got := transport.req.URL.RequestURI(); got != test.expectedURI {
-				t.Fatalf("request URI = %q, want %q", got, test.expectedURI)
-			}
-		})
-	}
-}
-
 func TestURLFromBaseURLPreservesRawPathAndQuery(t *testing.T) {
 	client := newTestFlapsClient(t, &managedPostgresRoundTripper{statusCode: http.StatusOK, body: `{}`})
 
@@ -345,37 +311,42 @@ func TestCreateManagedPostgresBackup(t *testing.T) {
 	}
 }
 
-func TestCreateManagedPostgresBackupEscapesClusterID(t *testing.T) {
-	transport := &managedPostgresRoundTripper{statusCode: http.StatusAccepted}
-	client := newTestFlapsClient(t, transport)
-
-	if err := client.CreateManagedPostgresBackup(context.Background(), "my?cluster", CreateManagedPostgresBackupRequest{Type: "full"}); err != nil {
-		t.Fatalf("CreateManagedPostgresBackup() error = %v", err)
+func TestManagedPostgresBackupsPreserveEscapedPath(t *testing.T) {
+	operations := []struct {
+		name       string
+		statusCode int
+		body       string
+		run        func(*Client, string) error
+	}{
+		{name: "list", statusCode: http.StatusOK, body: `{"data":[]}`, run: func(client *Client, id string) error {
+			_, err := client.ListManagedPostgresBackups(context.Background(), id)
+			return err
+		}},
+		{name: "create", statusCode: http.StatusAccepted, run: func(client *Client, id string) error {
+			return client.CreateManagedPostgresBackup(context.Background(), id, CreateManagedPostgresBackupRequest{Type: "full"})
+		}},
 	}
-	if got, want := transport.req.URL.EscapedPath(), "/v1/postgres/my%3Fcluster/backups"; got != want {
-		t.Fatalf("request path = %q, want %q", got, want)
-	}
-}
-
-func TestCreateManagedPostgresBackupPreservesEscapedPath(t *testing.T) {
-	for _, test := range []struct {
+	paths := []struct {
 		name        string
 		clusterID   string
 		expectedURI string
 	}{
 		{name: "slash", clusterID: "a/b", expectedURI: "/v1/postgres/a%2Fb/backups"},
-		{name: "slash and dot segment", clusterID: "a/../b", expectedURI: "/v1/postgres/a%2F..%2Fb/backups"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			transport := &managedPostgresRoundTripper{statusCode: http.StatusAccepted}
-			client := newTestFlapsClient(t, transport)
-			if err := client.CreateManagedPostgresBackup(context.Background(), test.clusterID, CreateManagedPostgresBackupRequest{Type: "full"}); err != nil {
-				t.Fatalf("CreateManagedPostgresBackup() error = %v", err)
-			}
-			if got := transport.req.URL.RequestURI(); got != test.expectedURI {
-				t.Fatalf("request URI = %q, want %q", got, test.expectedURI)
-			}
-		})
+		{name: "slash_and_dot_segment", clusterID: "a/../b", expectedURI: "/v1/postgres/a%2F..%2Fb/backups"},
+	}
+
+	for _, operation := range operations {
+		for _, path := range paths {
+			t.Run(operation.name+"/"+path.name, func(t *testing.T) {
+				transport := &managedPostgresRoundTripper{statusCode: operation.statusCode, body: operation.body}
+				if err := operation.run(newTestFlapsClient(t, transport), path.clusterID); err != nil {
+					t.Fatalf("request error = %v", err)
+				}
+				if got := transport.req.URL.RequestURI(); got != path.expectedURI {
+					t.Fatalf("request URI = %q, want %q", got, path.expectedURI)
+				}
+			})
+		}
 	}
 }
 

--- a/flaps/flapsaction_string.go
+++ b/flaps/flapsaction_string.go
@@ -75,11 +75,13 @@ func _() {
 	_ = x[managedPostgresDelete-64]
 	_ = x[managedPostgresDatabaseList-65]
 	_ = x[managedPostgresDatabaseCreate-66]
+	_ = x[managedPostgresBackupList-67]
+	_ = x[managedPostgresBackupCreate-68]
 }
 
-const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDeletemanagedPostgresDatabaseListmanagedPostgresDatabaseCreate"
+const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDeletemanagedPostgresDatabaseListmanagedPostgresDatabaseCreatemanagedPostgresBackupListmanagedPostgresBackupCreate"
 
-var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948, 975, 1004}
+var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948, 975, 1004, 1029, 1056}
 
 func (i flapsAction) String() string {
 	idx := int(i) - 0


### PR DESCRIPTION
## Summary

- add typed Flaps client methods for listing and creating Managed Postgres backups
- preserve escaped path segments in the shared Flaps URL builder
- cover response decoding, error classification, request bodies, and escaped cluster IDs

## Testing

- `go generate ./flaps`
- `go test ./... -count=1`