### PR TITLE
Add Managed Postgres user endpoints

### DIFF
--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -76,4 +76,8 @@ const (
 	managedPostgresBackupList
 	managedPostgresBackupCreate
 	managedPostgresRestore
+	managedPostgresUserList
+	managedPostgresUserCreate
+	managedPostgresUserUpdate
+	managedPostgresUserDelete
 )

--- a/flaps/flaps_managed_postgres.go
+++ b/flaps/flaps_managed_postgres.go
@@ -96,11 +96,21 @@ type ManagedPostgresUserCredentials struct {
 	Password string `json:"password"`
 }
 
+// ManagedPostgresUserRole is a role assigned to a Managed Postgres user.
+type ManagedPostgresUserRole string
+
+// Roles the API accepts when creating or updating a Managed Postgres user.
+const (
+	ManagedPostgresUserRoleSchemaAdmin ManagedPostgresUserRole = "schema_admin"
+	ManagedPostgresUserRoleWriter      ManagedPostgresUserRole = "writer"
+	ManagedPostgresUserRoleReader      ManagedPostgresUserRole = "reader"
+)
+
 // ManagedPostgresUser is the public projection of a user within a Managed
 // Postgres cluster.
 type ManagedPostgresUser struct {
-	Username string `json:"username"`
-	Role     string `json:"role"`
+	Username string                  `json:"username"`
+	Role     ManagedPostgresUserRole `json:"role"`
 }
 
 // CreateManagedPostgresUserRequest is the body for

--- a/flaps/flaps_managed_postgres.go
+++ b/flaps/flaps_managed_postgres.go
@@ -96,6 +96,26 @@ type ManagedPostgresUserCredentials struct {
 	Password string `json:"password"`
 }
 
+// ManagedPostgresUser is the public projection of a user within a Managed
+// Postgres cluster.
+type ManagedPostgresUser struct {
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+// CreateManagedPostgresUserRequest is the body for
+// POST /v1/postgres/:id/users.
+type CreateManagedPostgresUserRequest struct {
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+// UpdateManagedPostgresUserRoleRequest is the body for
+// PATCH /v1/postgres/:id/users/:username.
+type UpdateManagedPostgresUserRoleRequest struct {
+	Role string `json:"role"`
+}
+
 // ManagedPostgresDatabase is the public projection of a database within a
 // Managed Postgres cluster returned by list/create.
 type ManagedPostgresDatabase struct {
@@ -144,6 +164,14 @@ type managedPostgresClusterListEnvelope struct {
 
 type managedPostgresUserCredentialsEnvelope struct {
 	Data ManagedPostgresUserCredentials `json:"data"`
+}
+
+type managedPostgresUserEnvelope struct {
+	Data ManagedPostgresUser `json:"data"`
+}
+
+type managedPostgresUserListEnvelope struct {
+	Data []ManagedPostgresUser `json:"data"`
 }
 
 type managedPostgresDatabaseEnvelope struct {
@@ -221,6 +249,54 @@ func (f *Client) GetManagedPostgresUserCredentials(ctx context.Context, id, user
 	}
 
 	return env.Data, nil
+}
+
+func (f *Client) ListManagedPostgresUsers(ctx context.Context, id string) ([]ManagedPostgresUser, error) {
+	ctx = contextWithAction(ctx, managedPostgresUserList)
+
+	endpoint := fmt.Sprintf("/postgres/%s/users", url.PathEscape(id))
+
+	var env managedPostgresUserListEnvelope
+	if err := f._sendRequest(ctx, http.MethodGet, endpoint, nil, &env, nil); err != nil {
+		return nil, fmt.Errorf("failed to list Managed Postgres users: %w", err)
+	}
+
+	return env.Data, nil
+}
+
+func (f *Client) CreateManagedPostgresUser(ctx context.Context, id string, req CreateManagedPostgresUserRequest) (ManagedPostgresUser, error) {
+	ctx = contextWithAction(ctx, managedPostgresUserCreate)
+
+	endpoint := fmt.Sprintf("/postgres/%s/users", url.PathEscape(id))
+
+	var env managedPostgresUserEnvelope
+	if err := f._sendRequest(ctx, http.MethodPost, endpoint, req, &env, nil); err != nil {
+		return ManagedPostgresUser{}, fmt.Errorf("failed to create Managed Postgres user: %w", err)
+	}
+
+	return env.Data, nil
+}
+
+func (f *Client) UpdateManagedPostgresUserRole(ctx context.Context, id, username string, req UpdateManagedPostgresUserRoleRequest) error {
+	ctx = contextWithAction(ctx, managedPostgresUserUpdate)
+
+	endpoint := fmt.Sprintf("/postgres/%s/users/%s", url.PathEscape(id), url.PathEscape(username))
+	if err := f._sendRequest(ctx, http.MethodPatch, endpoint, req, nil, nil); err != nil {
+		return fmt.Errorf("failed to update Managed Postgres user role: %w", err)
+	}
+
+	return nil
+}
+
+func (f *Client) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
+	ctx = contextWithAction(ctx, managedPostgresUserDelete)
+
+	endpoint := fmt.Sprintf("/postgres/%s/users/%s", url.PathEscape(id), url.PathEscape(username))
+	if err := f._sendRequest(ctx, http.MethodDelete, endpoint, nil, nil, nil); err != nil {
+		return fmt.Errorf("failed to delete Managed Postgres user: %w", err)
+	}
+
+	return nil
 }
 
 func (f *Client) ListManagedPostgresDatabases(ctx context.Context, id string) ([]ManagedPostgresDatabase, error) {

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -144,11 +144,17 @@ func TestListManagedPostgresUsers(t *testing.T) {
 	if len(users) != 2 {
 		t.Fatalf("user count = %d, want 2", len(users))
 	}
-	if got, want := users[0], (ManagedPostgresUser{Username: "app_user", Role: "writer"}); got != want {
-		t.Fatalf("users[0] = %#v, want %#v", got, want)
+	if got, want := users[0].Username, "app_user"; got != want {
+		t.Fatalf("users[0].Username = %q, want %q", got, want)
 	}
-	if got, want := users[1], (ManagedPostgresUser{Username: "analyst", Role: "schema_admin"}); got != want {
-		t.Fatalf("users[1] = %#v, want %#v", got, want)
+	if got, want := users[0].Role, ManagedPostgresUserRoleWriter; got != want {
+		t.Fatalf("users[0].Role = %q, want %q", got, want)
+	}
+	if got, want := users[1].Username, "analyst"; got != want {
+		t.Fatalf("users[1].Username = %q, want %q", got, want)
+	}
+	if got, want := users[1].Role, ManagedPostgresUserRoleSchemaAdmin; got != want {
+		t.Fatalf("users[1].Role = %q, want %q", got, want)
 	}
 }
 
@@ -186,8 +192,11 @@ func TestCreateManagedPostgresUser(t *testing.T) {
 	if got, want := sent, (CreateManagedPostgresUserRequest{Username: "reporter", Role: "reader"}); got != want {
 		t.Fatalf("request body = %#v, want %#v", got, want)
 	}
-	if got, want := user, (ManagedPostgresUser{Username: "reporter", Role: "reader"}); got != want {
-		t.Fatalf("user = %#v, want %#v", got, want)
+	if got, want := user.Username, "reporter"; got != want {
+		t.Fatalf("user.Username = %q, want %q", got, want)
+	}
+	if got, want := user.Role, ManagedPostgresUserRoleReader; got != want {
+		t.Fatalf("user.Role = %q, want %q", got, want)
 	}
 }
 
@@ -353,6 +362,12 @@ func TestManagedPostgresUsersPreserveNonNotFoundErrors(t *testing.T) {
 		}},
 		{name: "update_unprocessable", statusCode: http.StatusUnprocessableEntity, run: func(client *Client) error {
 			return client.UpdateManagedPostgresUserRole(context.Background(), "mpg-123", "reporter", UpdateManagedPostgresUserRoleRequest{Role: "invalid"})
+		}},
+		// Deleting a reserved user (postgres, flypgadmin, …) is rejected with
+		// 400 by the API. It must surface as a FlapsError carrying that status,
+		// not be silently swallowed or misclassified as 404.
+		{name: "delete_bad_request", statusCode: http.StatusBadRequest, run: func(client *Client) error {
+			return client.DeleteManagedPostgresUser(context.Background(), "mpg-123", "postgres")
 		}},
 	}
 

--- a/flaps/flaps_managed_postgres_test.go
+++ b/flaps/flaps_managed_postgres_test.go
@@ -121,6 +121,259 @@ func TestDeleteManagedPostgresClusterClassifiesGone(t *testing.T) {
 	}
 }
 
+func TestListManagedPostgresUsers(t *testing.T) {
+	transport := &managedPostgresRoundTripper{
+		statusCode: http.StatusOK,
+		body:       `{"data":[{"username":"app_user","role":"writer"},{"username":"analyst","role":"schema_admin"}]}`,
+	}
+	client := newTestFlapsClient(t, transport)
+
+	users, err := client.ListManagedPostgresUsers(context.Background(), "mpg-123")
+	if err != nil {
+		t.Fatalf("ListManagedPostgresUsers() error = %v", err)
+	}
+	if got, want := transport.req.Method, http.MethodGet; got != want {
+		t.Fatalf("request method = %q, want %q", got, want)
+	}
+	if got, want := transport.req.URL.RequestURI(), "/v1/postgres/mpg-123/users"; got != want {
+		t.Fatalf("request URI = %q, want %q", got, want)
+	}
+	if got, want := actionFromContext(transport.req.Context()), managedPostgresUserList; got != want {
+		t.Fatalf("request action = %q, want %q", got, want)
+	}
+	if len(users) != 2 {
+		t.Fatalf("user count = %d, want 2", len(users))
+	}
+	if got, want := users[0], (ManagedPostgresUser{Username: "app_user", Role: "writer"}); got != want {
+		t.Fatalf("users[0] = %#v, want %#v", got, want)
+	}
+	if got, want := users[1], (ManagedPostgresUser{Username: "analyst", Role: "schema_admin"}); got != want {
+		t.Fatalf("users[1] = %#v, want %#v", got, want)
+	}
+}
+
+func TestCreateManagedPostgresUser(t *testing.T) {
+	transport := &managedPostgresRoundTripper{
+		statusCode: http.StatusCreated,
+		body:       `{"data":{"username":"reporter","role":"reader"}}`,
+	}
+	client := newTestFlapsClient(t, transport)
+
+	user, err := client.CreateManagedPostgresUser(context.Background(), "mpg-123", CreateManagedPostgresUserRequest{
+		Username: "reporter",
+		Role:     "reader",
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedPostgresUser() error = %v", err)
+	}
+	if got, want := transport.req.Method, http.MethodPost; got != want {
+		t.Fatalf("request method = %q, want %q", got, want)
+	}
+	if got, want := transport.req.URL.RequestURI(), "/v1/postgres/mpg-123/users"; got != want {
+		t.Fatalf("request URI = %q, want %q", got, want)
+	}
+	if got, want := actionFromContext(transport.req.Context()), managedPostgresUserCreate; got != want {
+		t.Fatalf("request action = %q, want %q", got, want)
+	}
+	body, err := io.ReadAll(transport.req.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var sent CreateManagedPostgresUserRequest
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decode request body %q: %v", string(body), err)
+	}
+	if got, want := sent, (CreateManagedPostgresUserRequest{Username: "reporter", Role: "reader"}); got != want {
+		t.Fatalf("request body = %#v, want %#v", got, want)
+	}
+	if got, want := user, (ManagedPostgresUser{Username: "reporter", Role: "reader"}); got != want {
+		t.Fatalf("user = %#v, want %#v", got, want)
+	}
+}
+
+func TestUpdateManagedPostgresUserRole(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNoContent}
+	client := newTestFlapsClient(t, transport)
+
+	err := client.UpdateManagedPostgresUserRole(context.Background(), "mpg-123", "reporter", UpdateManagedPostgresUserRoleRequest{Role: "writer"})
+	if err != nil {
+		t.Fatalf("UpdateManagedPostgresUserRole() error = %v", err)
+	}
+	if got, want := transport.req.Method, http.MethodPatch; got != want {
+		t.Fatalf("request method = %q, want %q", got, want)
+	}
+	if got, want := transport.req.URL.RequestURI(), "/v1/postgres/mpg-123/users/reporter"; got != want {
+		t.Fatalf("request URI = %q, want %q", got, want)
+	}
+	if got, want := actionFromContext(transport.req.Context()), managedPostgresUserUpdate; got != want {
+		t.Fatalf("request action = %q, want %q", got, want)
+	}
+	body, err := io.ReadAll(transport.req.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var sent UpdateManagedPostgresUserRoleRequest
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decode request body %q: %v", string(body), err)
+	}
+	if got, want := sent.Role, "writer"; got != want {
+		t.Fatalf("sent role = %q, want %q", got, want)
+	}
+}
+
+func TestDeleteManagedPostgresUser(t *testing.T) {
+	transport := &managedPostgresRoundTripper{statusCode: http.StatusNoContent}
+	client := newTestFlapsClient(t, transport)
+
+	if err := client.DeleteManagedPostgresUser(context.Background(), "mpg-123", "reporter"); err != nil {
+		t.Fatalf("DeleteManagedPostgresUser() error = %v", err)
+	}
+	if got, want := transport.req.Method, http.MethodDelete; got != want {
+		t.Fatalf("request method = %q, want %q", got, want)
+	}
+	if got, want := transport.req.URL.RequestURI(), "/v1/postgres/mpg-123/users/reporter"; got != want {
+		t.Fatalf("request URI = %q, want %q", got, want)
+	}
+	if got, want := actionFromContext(transport.req.Context()), managedPostgresUserDelete; got != want {
+		t.Fatalf("request action = %q, want %q", got, want)
+	}
+	if transport.req.Body != nil {
+		t.Fatalf("request body is non-nil")
+	}
+}
+
+func TestManagedPostgresUsersPreserveEscapedPaths(t *testing.T) {
+	operations := []struct {
+		name       string
+		statusCode int
+		body       string
+		run        func(*Client, string, string) error
+	}{
+		{name: "list", statusCode: http.StatusOK, body: `{"data":[]}`, run: func(client *Client, id, _ string) error {
+			_, err := client.ListManagedPostgresUsers(context.Background(), id)
+			return err
+		}},
+		{name: "create", statusCode: http.StatusCreated, body: `{"data":{"username":"new_user","role":"reader"}}`, run: func(client *Client, id, _ string) error {
+			_, err := client.CreateManagedPostgresUser(context.Background(), id, CreateManagedPostgresUserRequest{Username: "new_user", Role: "reader"})
+			return err
+		}},
+		{name: "update", statusCode: http.StatusNoContent, run: func(client *Client, id, username string) error {
+			return client.UpdateManagedPostgresUserRole(context.Background(), id, username, UpdateManagedPostgresUserRoleRequest{Role: "reader"})
+		}},
+		{name: "delete", statusCode: http.StatusNoContent, run: func(client *Client, id, username string) error {
+			return client.DeleteManagedPostgresUser(context.Background(), id, username)
+		}},
+	}
+	paths := []struct {
+		name        string
+		clusterID   string
+		username    string
+		expectedURI func(string) string
+	}{
+		{name: "slash", clusterID: "a/b", username: "user/name", expectedURI: func(operation string) string {
+			if operation == "list" || operation == "create" {
+				return "/v1/postgres/a%2Fb/users"
+			}
+
+			return "/v1/postgres/a%2Fb/users/user%2Fname"
+		}},
+		{name: "slash_and_dot_segment", clusterID: "a/../b", username: "user/../name", expectedURI: func(operation string) string {
+			if operation == "list" || operation == "create" {
+				return "/v1/postgres/a%2F..%2Fb/users"
+			}
+
+			return "/v1/postgres/a%2F..%2Fb/users/user%2F..%2Fname"
+		}},
+	}
+
+	for _, operation := range operations {
+		for _, path := range paths {
+			t.Run(operation.name+"/"+path.name, func(t *testing.T) {
+				transport := &managedPostgresRoundTripper{statusCode: operation.statusCode, body: operation.body}
+				if err := operation.run(newTestFlapsClient(t, transport), path.clusterID, path.username); err != nil {
+					t.Fatalf("request error = %v", err)
+				}
+				if got, want := transport.req.URL.RequestURI(), path.expectedURI(operation.name); got != want {
+					t.Fatalf("request URI = %q, want %q", got, want)
+				}
+			})
+		}
+	}
+}
+
+func TestManagedPostgresUsersClassifyNotFound(t *testing.T) {
+	operations := []struct {
+		name string
+		run  func(*Client) error
+	}{
+		{name: "list", run: func(client *Client) error {
+			_, err := client.ListManagedPostgresUsers(context.Background(), "missing")
+			return err
+		}},
+		{name: "create", run: func(client *Client) error {
+			_, err := client.CreateManagedPostgresUser(context.Background(), "missing", CreateManagedPostgresUserRequest{Username: "reporter", Role: "reader"})
+			return err
+		}},
+		{name: "update", run: func(client *Client) error {
+			return client.UpdateManagedPostgresUserRole(context.Background(), "mpg-123", "missing", UpdateManagedPostgresUserRoleRequest{Role: "reader"})
+		}},
+		{name: "delete", run: func(client *Client) error {
+			return client.DeleteManagedPostgresUser(context.Background(), "mpg-123", "missing")
+		}},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			transport := &managedPostgresRoundTripper{statusCode: http.StatusNotFound, body: `{"error":"not found"}`}
+			err := operation.run(newTestFlapsClient(t, transport))
+			if !errors.Is(err, ErrFlapsNotFound) {
+				t.Fatalf("request error = %v, want ErrFlapsNotFound", err)
+			}
+			var flapsErr *FlapsError
+			if !errors.As(err, &flapsErr) {
+				t.Fatalf("request error = %v, want wrapped FlapsError", err)
+			}
+		})
+	}
+}
+
+func TestManagedPostgresUsersPreserveNonNotFoundErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		run        func(*Client) error
+	}{
+		{name: "create_bad_request", statusCode: http.StatusBadRequest, run: func(client *Client) error {
+			_, err := client.CreateManagedPostgresUser(context.Background(), "mpg-123", CreateManagedPostgresUserRequest{Username: "reporter", Role: "invalid"})
+			return err
+		}},
+		{name: "create_conflict", statusCode: http.StatusConflict, run: func(client *Client) error {
+			_, err := client.CreateManagedPostgresUser(context.Background(), "mpg-123", CreateManagedPostgresUserRequest{Username: "reporter", Role: "reader"})
+			return err
+		}},
+		{name: "update_unprocessable", statusCode: http.StatusUnprocessableEntity, run: func(client *Client) error {
+			return client.UpdateManagedPostgresUserRole(context.Background(), "mpg-123", "reporter", UpdateManagedPostgresUserRoleRequest{Role: "invalid"})
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &managedPostgresRoundTripper{statusCode: test.statusCode, body: `{"error":"request rejected"}`}
+			err := test.run(newTestFlapsClient(t, transport))
+			if errors.Is(err, ErrFlapsNotFound) {
+				t.Fatalf("request error = %v, unexpectedly classified as not found", err)
+			}
+			var flapsErr *FlapsError
+			if !errors.As(err, &flapsErr) {
+				t.Fatalf("request error = %v, want FlapsError", err)
+			}
+			if got, want := flapsErr.ResponseStatusCode, test.statusCode; got != want {
+				t.Fatalf("response status = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
 func TestListManagedPostgresDatabases(t *testing.T) {
 	transport := &managedPostgresRoundTripper{
 		statusCode: http.StatusOK,

--- a/flaps/flapsaction_string.go
+++ b/flaps/flapsaction_string.go
@@ -78,11 +78,15 @@ func _() {
 	_ = x[managedPostgresBackupList-67]
 	_ = x[managedPostgresBackupCreate-68]
 	_ = x[managedPostgresRestore-69]
+	_ = x[managedPostgresUserList-70]
+	_ = x[managedPostgresUserCreate-71]
+	_ = x[managedPostgresUserUpdate-72]
+	_ = x[managedPostgresUserDelete-73]
 }
 
-const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDeletemanagedPostgresDatabaseListmanagedPostgresDatabaseCreatemanagedPostgresBackupListmanagedPostgresBackupCreatemanagedPostgresRestore"
+const _flapsAction_name = "noneappCreateappGetmachineLaunchmachineUpdatemachineStartmachineWaitmachineStopmachineRestartmachineGetmachineListmachineDestroymachineKillmachineFindLeasemachineAcquireLeasemachineRefreshLeasemachineReleaseLeasemachineExecmachinePsmachineCordonmachineUncordonmachineSuspendappSecretsListappSecretGetappSecretSetappSecretDeleteappSecretUpdateipAssignmentListipAssignmentCreateipAssignmentDeletesecretkeysListsecretkeyGetsecretkeySetsecretkeyGeneratesecretkeyDeletesecretkeyEncryptsecretkeyDecryptsecretkeySignsecretkeyVerifyvolumeListvolumeCreatevolumetUpdatevolumeGetvolumeSnapshotCreatevolumeSnapshotListvolumeExtendvolumeDeletemetadataSetmetadataGetmetadataDelregionsGetplacementPostcertificateListcertificateCreateACMEcertificateCreateCustomcertificateGetcertificateCheckcertificateDeletecertificateDeleteACMEcertificateDeleteCustommanagedPostgresCreatemanagedPostgresGetmanagedPostgresUserCredentialsGetmanagedPostgresListmanagedPostgresDeletemanagedPostgresDatabaseListmanagedPostgresDatabaseCreatemanagedPostgresBackupListmanagedPostgresBackupCreatemanagedPostgresRestoremanagedPostgresUserListmanagedPostgresUserCreatemanagedPostgresUserUpdatemanagedPostgresUserDelete"
 
-var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948, 975, 1004, 1029, 1056, 1078}
+var _flapsAction_index = [...]uint16{0, 4, 13, 19, 32, 45, 57, 68, 79, 93, 103, 114, 128, 139, 155, 174, 193, 212, 223, 232, 245, 260, 274, 288, 300, 312, 327, 342, 358, 376, 394, 408, 420, 432, 449, 464, 480, 496, 509, 524, 534, 546, 559, 568, 588, 606, 618, 630, 641, 652, 663, 673, 686, 701, 722, 745, 759, 775, 792, 813, 836, 857, 875, 908, 927, 948, 975, 1004, 1029, 1056, 1078, 1101, 1126, 1151, 1176}
 
 func (i flapsAction) String() string {
 	idx := int(i) - 0


### PR DESCRIPTION
## Summary
- `ListManagedPostgresUsers` — `GET /v1/postgres/:id/users`, 200 with a `{"data": [...]}` envelope
- `CreateManagedPostgresUser` — `POST /v1/postgres/:id/users`, 201 with a `{"data": {...}}` envelope
- `UpdateManagedPostgresUserRole` — `PATCH /v1/postgres/:id/users/:username`, 204 with no body
- `DeleteManagedPostgresUser` — `DELETE /v1/postgres/:id/users/:username`, 204 with no body

Cluster IDs and usernames are path-escaped with `url.PathEscape`. Each call carries one of four new `flapsAction` values for request tracing.

## Test plan
- `go test ./...`
- Request method, URI, action, and body coverage for all four endpoints
- Role coverage for `reader`, `writer`, and `schema_admin`
- Escaped-path and dot-segment preservation
- 404 classification as `ErrFlapsNotFound`
- Non-404 errors preserve their `FlapsError` status